### PR TITLE
respect ES `--limit` by dividing by shard count

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -51,43 +51,67 @@ elasticsearch.prototype.getData = function (limit, offset, callback){
     if (self.lastScrollId !== null) {
         scrollResultSet(self, callback);
     } else {
-        uri = self.baseUrl +
-              "/" +
-              "_search?search_type=scan&scroll=" +
-              self.parent.options.scrollTime +
-              "&size=" + self.parent.options.limit;
+        elasticsearch.prototype.numberOfShards(self.baseUrl ,function(err, numberOfShards){
+            var shardedLimit = Math.ceil(limit / numberOfShards);
 
-        searchBody = {
-            "query": {
-                "match_all": {}
-            },
-            "size": limit
-        };
+            uri = self.baseUrl +
+                  "/" +
+                  "_search?search_type=scan&scroll=" +
+                  self.parent.options.scrollTime +
+                  "&size=" + shardedLimit;
 
-        searchRequest = {
-            "uri": uri,
-            "method": "GET",
-            "body": JSON.stringify(searchBody)
-        };
+            searchBody = {
+                "query": {
+                    "match_all": {}
+                },
+                "size": shardedLimit
+            };
 
-        request.get(searchRequest, function requestResonse (err, response) {
-            if(err != null){
-                callback(err, []);
-                return;
-            }else if(response.statusCode != 200){
-                err = new Error(response.body);
-                callback(err, []);
-                return;
-            }
+            searchRequest = {
+                "uri": uri,
+                "method": "GET",
+                "body": JSON.stringify(searchBody)
+            };
 
-            var body = JSON.parse(response.body);
-            self.lastScrollId = body._scroll_id;
-            self.totalSearchResults = body.hits.total;
+            request.get(searchRequest, function requestResonse (err, response) {
+                if(err != null){
+                    callback(err, []);
+                    return;
+                }else if(response.statusCode != 200){
+                    err = new Error(response.body);
+                    callback(err, []);
+                    return;
+                }
 
-            scrollResultSet(self, callback);
+                var body = JSON.parse(response.body);
+                self.lastScrollId = body._scroll_id;
+                self.totalSearchResults = body.hits.total;
+
+                scrollResultSet(self, callback);
+            });
         });
     }
 };
+
+// to respect the --limit param, we need to set the scan/sroll limit = limit/#Shards
+// http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/scan-scroll.html
+elasticsearch.prototype.numberOfShards = function(baseUrl, callback){
+    request.get(baseUrl + "/_settings", function(err, response){
+        if(err != null){
+            callback(err)
+        }else{
+            try{
+                body = JSON.parse(response.body);
+                var indexParts = baseUrl.split('/');
+                var index = indexParts[(indexParts.length - 1)];    
+                var numberOfShards = body[index].settings.index.number_of_shards;
+                callback(err, numberOfShards);
+            }catch(e){
+                callback(err, 1);
+            }
+        }
+    });
+}
 
 // accept arr, callback where arr is an array of objects
 // return (error, writes)
@@ -266,6 +290,7 @@ function scrollResultSet(that, callback) {
         "method": "POST",
         "body": self.lastScrollId
     };
+
     request.get(scrollRequest, function requestResonse (err, response) {
         if(response.statusCode != 200 && err == null){
             err = new Error(response.body);


### PR DESCRIPTION
Now that we are using the scan/scroll API to load data from Elasticsearch, we need to modify how the flag `--limit` is treated in reads.  

In most Elasticsearch APIs, limit is literal, in that if you say `{size: 100}`, you will get 100 results.  However, the scan/scroll API is special, in that it tries to minimize load on each shard and does not pre-collect results before transmitting.  The `size` in this API is actually results per-shard.  So if you have 5 shards and say `{size: 100}`, you will actually get ~500 results back (assuming the shard has unsent data to return).

This PR attempts to look up how many shards and index has, and will modify the effective `{size}` to be `limit / shards`. 
