### PR TITLE
use lineReader rather than readline to better handle memory leaks

### DIFF
--- a/elasticdump.js
+++ b/elasticdump.js
@@ -4,28 +4,30 @@ var https = require("https");
 var EventEmitter = require('events').EventEmitter;
 
 var elasticdump = function(input, output, options){
-  this.input   = input;
-  this.output  = output;
-  this.options = options;
+  var self  = this;
 
-  this.validateOptions();  
-  this.toLog = true;
+  self.input   = input;
+  self.output  = output;
+  self.options = options;
 
-  if(this.options.input == "$"){
-    this.inputType = 'stdio'; 
-  }else if(this.options.input.indexOf(":") >= 0){
-    this.inputType = 'elasticsearch';
+  self.validateOptions();  
+  self.toLog = true;
+
+  if(self.options.input == "$"){
+    self.inputType = 'stdio'; 
+  }else if(self.options.input.indexOf(":") >= 0){
+    self.inputType = 'elasticsearch';
   }else{
-    this.inputType  = 'file';
+    self.inputType  = 'file';
   }
 
-  if(this.options.output == "$"){
-    this.outputType = 'stdio'; 
-    this.toLog = false;
-  }else if(this.options.output.indexOf(":") >= 0){
-    this.outputType = 'elasticsearch';
+  if(self.options.output == "$"){
+    self.outputType = 'stdio'; 
+    self.toLog = false;
+  }else if(self.options.output.indexOf(":") >= 0){
+    self.outputType = 'elasticsearch';
   }else{
-    this.outputType = 'file';
+    self.outputType = 'file';
   }
 
   if(options.maxSockets != null){
@@ -34,17 +36,18 @@ var elasticdump = function(input, output, options){
     https.globalAgent.maxSockets = options.maxSockets;
   }
 
-  var inputProto  = require(__dirname + "/lib/transports/" + this.inputType)[this.inputType];
-  var outputProto = require(__dirname + "/lib/transports/" + this.outputType)[this.outputType];
+  var inputProto  = require(__dirname + "/lib/transports/" + self.inputType)[self.inputType];
+  var outputProto = require(__dirname + "/lib/transports/" + self.outputType)[self.outputType];
 
-  this.input  = (new inputProto(this, this.options.input));
-  this.output = (new outputProto(this, this.options.output));
+  self.input  = (new inputProto(self, self.options.input));
+  self.output = (new outputProto(self, self.options.output));
 }
 
 util.inherits(elasticdump, EventEmitter);
 
 elasticdump.prototype.log = function(message){
   var self = this;
+
   if(typeof self.options.logger === 'function'){
     self.options.logger(message);
   }else if(self.toLog === true){
@@ -59,6 +62,7 @@ elasticdump.prototype.validateOptions = function(){
 
 elasticdump.prototype.dump = function(callback, continuing, limit, offset, total_writes){
   var self  = this;
+  
   if(limit  == null){ limit = self.options.limit;  }
   if(offset == null){ offset = self.options.offset; }
   if(total_writes == null){ total_writes = 0; }

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -51,7 +51,7 @@ elasticsearch.prototype.getData = function (limit, offset, callback){
     if (self.lastScrollId !== null) {
         scrollResultSet(self, callback);
     } else {
-        elasticsearch.prototype.numberOfShards(self.baseUrl ,function(err, numberOfShards){
+        self.numberOfShards(self.baseUrl ,function(err, numberOfShards){
             var shardedLimit = Math.ceil(limit / numberOfShards);
 
             uri = self.baseUrl +
@@ -101,7 +101,7 @@ elasticsearch.prototype.numberOfShards = function(baseUrl, callback){
             callback(err)
         }else{
             try{
-                body = JSON.parse(response.body);
+                var body = JSON.parse(response.body);
                 var indexParts = baseUrl.split('/');
                 var index = indexParts[(indexParts.length - 1)];    
                 var numberOfShards = body[index].settings.index.number_of_shards;
@@ -128,7 +128,7 @@ elasticsearch.prototype.set = function(data, limit, offset, callback){
 }
 
 elasticsearch.prototype.setMapping = function(data, limit, offset, callback){
-    var self           = this;
+    var self = this;
     if(self.haveSetMapping === true){
         callback(null, 0);
     }else{

--- a/lib/transports/file.js
+++ b/lib/transports/file.js
@@ -1,60 +1,48 @@
-var fs       = require('fs');
-var readline = require('readline');
+var fs         = require('fs');
+var lineReader = require('line-reader');
 
 var file = function(parent, file){
   this.file   = file;
   this.parent = parent;
   this.getLineCounter = 0;
   this.setLineCounter = 0;
-  this.readLines      = [];
   this.ready          = false;
+  this.reader         = null;
 }
 
-file.prototype.flush = function(error, limit, callback){
-  var self        = this;
-  var data        = [];
-  self.readStream.pause();
-  data = self.readLines.splice(0, Math.min(self.readLines.length, limit));
-  callback(error, data);
-}
 
 // accept callback
 // return (error, arr) where arr is an array of objects
 file.prototype.get = function(limit, offset, callback){
-  var self        = this;
+  var self = this;
   
-  if(self.readStream == null){
-    var error           = null;
-    var instream        = fs.createReadStream(self.file);
-    var outstream       = new Buffer(0);
-    self.readStream     = readline.createInterface(instream, outstream);
-    
-    self.readStream.on('line', function(line){
-      try{
-        if(line[0] == ','){ line = line.substring(1); }
-        line = line.trim();
-        if(line.length > 1){ 
-          self.readLines.push( JSON.parse(line) );
-        }
-        if(!self.ready || self.readLines.length < limit) return;
-        self.ready = false;
-        self.flush(error, limit, callback);
-      }catch(e){ error = e; }
-    });  
-    
-    self.readStream.on('close', function(line){
-      try{
-        if(!self.ready){ self.ready = true; }
-        else{ self.flush(error, limit, callback); }
-      }catch(e){ error = e; }
-    });  
-  }
-
-  if(!self.ready && self.readLines.length < limit){
-    self.ready = true;
-    self.readStream.input.resume();
+  if(self.reader == null){
+    lineReader.open(self.file, function(reader){
+      self.reader  = reader;
+      self.getLines(limit, offset, callback);
+    });
   }else{
-    self.flush(error, limit, callback);
+    self.getLines(limit, offset, callback);
+  }
+}
+
+file.prototype.getLines = function(limit, offset, callback, data){
+  var self = this;
+  if(data == null){ data = []; }
+  
+  if(data.length >= limit){
+    callback(null, data);
+  }else if( self.reader.hasNextLine() ){
+    self.reader.nextLine(function(line){
+      if(line[0] == ','){ line = line.substring(1); }
+      line = line.trim();
+      if(line.length > 1){ 
+        data.push( JSON.parse(line) );
+      }
+      self.getLines(limit, offset, callback, data);
+    });
+  }else{
+    callback(null, data);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "optimist": "latest",
     "request": "2.x.x",
-    "JSONStream": "0.7.x"
+    "JSONStream": "0.7.x",
+    "line-reader": "0.2.x"
   },
   "devDependencies": {
     "mocha": "latest",


### PR DESCRIPTION
... and some general cleanup

Previously, it only took a few K documents read from json to cause a huge heap.  This can be confirmed with https://github.com/c4milo/node-webkit-agent (and you would have noticed your dump grind to a halt).
