### PR TITLE
Fixed documentId escaping

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -122,7 +122,7 @@ elasticsearch.prototype.set = function(data, limit, offset, callback){
       stated++;
       var thisUrl = self.baseUrl + "/";
       if(self.parent.options.all === true){ thisUrl += elem._index + "/"; }
-      thisUrl += elem._type + "/" + elem._id;
+      thisUrl += elem._type + "/" + encodeURIComponent(elem._id);
       var payload = {
         url:  thisUrl,
         body: JSON.stringify(elem._source),


### PR DESCRIPTION
The elem._id should be escaped 
