### PR TITLE
Fix main filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git://github.com/taskrabbit/elasticsearch-dump.git"
   },
-  "main": "elasticsearch-dump.js",
+  "main": "elasticdump.js",
   "keywords": ["elasticsearch", "dump", "elasticdump", "import", "export", "transfer", "migrate", "migartion"],
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
I tried using this module in my automation script, but node kept telling me that module 'elasticdump' could not be found. Soon I figured out that there's a mistake in `package.json`. Please fix this, thanks.
