### PR TITLE
Add option --ignore-es-write-errors=false to abort immediately on a 400/500 response from ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     Will continue the read/write loop on write error
                     (default: false)
 --ignore-es-write-errors
-                    Will continue the read/write loop on an write error from elasticsearch
+                    Will continue the read/write loop on a write error from elasticsearch
                     (default: true)
 --scrollTime
                     Time the nodes will hold the requested search in order.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
 --ignore-errors
                     Will continue the read/write loop on write error
                     (default: false)
+--ignore-es-write-errors
+                    Will continue the read/write loop on an write error from elasticsearch
+                    (default: true)
 --scrollTime
                     Time the nodes will hold the requested search in order.
                     (default: 10m)

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -25,6 +25,7 @@ var defaults = {
   jsonLines: false,
   format: '',
   'ignore-errors': false,
+  'ignore-es-write-errors': true,
   scrollTime: '10m',
   timeout: null,
   toLog: null,

--- a/elasticdump.js
+++ b/elasticdump.js
@@ -80,7 +80,8 @@ var elasticdump = function (input, output, options) {
 
     var outputOpts = {
       index: self.options['output-index'],
-      headers: self.options['headers']
+      headers: self.options['headers'],
+      ignoreWriteErrors: self.options['ignore-es-write-errors']
     }
     OutputProto = require(path.join(__dirname, 'lib', 'transports', self.outputType))[self.outputType]
     self.output = (new OutputProto(self, self.options.output, outputOpts))

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -45,7 +45,7 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     Will continue the read/write loop on write error
                     (default: false)
 --ignore-es-write-errors
-                    Will continue the read/write loop on an write error from elasticsearch
+                    Will continue the read/write loop on a write error from elasticsearch
                     (default: true)
 --scrollTime
                     Time the nodes will hold the requested search in order.

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -44,6 +44,9 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
 --ignore-errors
                     Will continue the read/write loop on write error
                     (default: false)
+--ignore-es-write-errors
+                    Will continue the read/write loop on an write error from elasticsearch
+                    (default: true)
 --scrollTime
                     Time the nodes will hold the requested search in order.
                     (default: 10m)

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -17,7 +17,7 @@ var elasticsearch = function (parent, url, options) {
       'User-Agent': 'elasticdump'
     }, options.headers)
   })
-  this.ignoreWriteErrors = (options.ignoreWriteErrors !== null) ? options.ignoreWriteErrors : true;
+  this.ignoreWriteErrors = (options.ignoreWriteErrors !== null) ? options.ignoreWriteErrors : true
 }
 // accept callback
 // return (error, arr) where arr is an array of objects
@@ -436,7 +436,7 @@ elasticsearch.prototype.setData = function (data, limit, offset, callback) {
             } else if (self.ignoreWriteErrors) {
               console.error(item['index'])
             } else {
-              return callback(item['index']);
+              return callback(item['index'])
             }
           })
         }

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -17,6 +17,7 @@ var elasticsearch = function (parent, url, options) {
       'User-Agent': 'elasticdump'
     }, options.headers)
   })
+  this.ignoreWriteErrors = (options.ignoreWriteErrors !== null) ? options.ignoreWriteErrors : true;
 }
 // accept callback
 // return (error, arr) where arr is an array of objects
@@ -432,8 +433,10 @@ elasticsearch.prototype.setData = function (data, limit, offset, callback) {
           r.items.forEach(function (item) {
             if (item['index'].status < 400) {
               writes++
-            } else {
+            } else if (self.ignoreWriteErrors) {
               console.error(item['index'])
+            } else {
+              return callback(item['index']);
             }
           })
         }


### PR DESCRIPTION
Defaults to `true` to maintain existing behaviour.

Fixes taskrabbit/elasticsearch-dump#369