### PR TITLE
added support for `awsRegex` flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,9 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
 --awsRegion
                     Sets the AWS region that the signature will be generated for
                     (default: calculated from hostname or host)
+--awsRegex
+                    Regular expression that defined valied AWS urls that should be signed
+                    (default: https?:\\.*.amazonaws.com.*)
 --support-big-int   
                     Support big integer numbers
 --big-int-fields   

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -44,6 +44,7 @@ const defaults = {
   awsIniFileProfile: null,
   awsService: null,
   awsRegion: null,
+  awsRegex: null,
   s3AccessKeyId: null,
   s3SecretAccessKey: null,
   s3Region: null,

--- a/lib/aws4signer.js
+++ b/lib/aws4signer.js
@@ -11,6 +11,11 @@ const aws4signer = (esRequest, parent) => {
   // Consider deprecating - can be achieved with awsChain and setting AWS_PROFILE and AWS_CONFIG_FILE environment variables as needed
   const useAwsProfile = (typeof parent.options.awsIniFileProfile === 'string')
   const useAwsChain = (parent.options.awsChain === true)
+  const awsRegex = new RegExp(parent.options.awsRegex || /https?:\/\/.*\.amazonaws\.com.*/)
+
+  if (!awsRegex.test(esRequest.url) && !awsRegex.test(esRequest.uri)) {
+    return
+  }
 
   if (useAwsCredentials || useAwsProfile || useAwsChain) {
     // Lazy load credentials object depending on our flavor of credential loading

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -165,6 +165,9 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
 --awsRegion
                     Sets the AWS region that the signature will be generated for
                     (default: calculated from hostname or host)
+--awsRegex
+                    Regular expression that defined valied AWS urls that should be signed
+                    (default: https?:\\.*.amazonaws.com.*)
 --transform
                     A javascript, which will be called to modify documents
                     before writing it to destination. global variable 'doc'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "JSONStream": "^1.3.5",
     "async": "^2.0.1",
-    "aws-sdk": "^2.696.0",
+    "aws-sdk": "^2.699.0",
     "aws4": "^1.10.0",
     "big.js": "^5.2.2",
     "bytes": "^3.1.0",

--- a/test/aws4signing.js
+++ b/test/aws4signing.js
@@ -7,7 +7,7 @@ var chainParent = { options: { awsChain: true } }
 describe('aws4signer', function () {
   it('should parse "uri" from request object and add signature, if credentials provided', function () {
     var r = {
-      uri: 'http://127.0.0.1:9200/_search?q=test',
+      uri: 'http://es.aws.amazonaws.com:9200/_search?q=test',
       method: 'GET',
       body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
     }
@@ -18,7 +18,7 @@ describe('aws4signer', function () {
 
   it('should parse "url" from request object and add signature, if credentials provided', function () {
     var r = {
-      url: 'http://127.0.0.1:9200/_search?q=test',
+      url: 'http://es.aws.amazonaws.com:9200/_search?q=test',
       method: 'GET',
       body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
     }
@@ -28,7 +28,7 @@ describe('aws4signer', function () {
 
   it('should parse "url" from request object and add signature, if AWS profile info provided', function () {
     var r = {
-      url: 'http://127.0.0.1:9200/_search?q=test',
+      url: 'http://es.aws.amazonaws.com:9200/_search?q=test',
       method: 'GET',
       body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
     }
@@ -38,7 +38,7 @@ describe('aws4signer', function () {
 
   it('should parse "url" from request object and add signature, if AWS Chain option provided', function () {
     var r = {
-      url: 'http://127.0.0.1:9200/_search?q=test',
+      url: 'http://es.aws.amazonaws.com:9200/_search?q=test',
       method: 'GET',
       body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
     }
@@ -48,7 +48,7 @@ describe('aws4signer', function () {
 
   it('should not add signature if credential (key, secret) is NOT provided', function () {
     var r = {
-      uri: 'http://127.0.0.1:9200/_search?q=test',
+      uri: 'http://es.aws.amazonaws.com:9200/_search?q=test',
       method: 'GET',
       body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
     }
@@ -62,7 +62,7 @@ describe('aws4signer', function () {
 
   it('should not add signature if credential (secret or key) is NOT provided', function () {
     var r = {
-      uri: 'http://127.0.0.1:9200/_search?q=test',
+      uri: 'http://es.aws.amazonaws.com:9200/_search?q=test',
       method: 'GET',
       body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
     }


### PR DESCRIPTION
This allows a user to override the default regex that aws urls that should be signed.

fixes #707