### PR TITLE
Resolve transform file path better

### DIFF
--- a/elasticdump.js
+++ b/elasticdump.js
@@ -4,7 +4,7 @@ const TransportProcessor = require('./lib/processor')
 const vm = require('vm')
 const { promisify } = require('util')
 const ioHelper = require('./lib/ioHelper')
-const url = require('url')
+const path = require('path')
 
 class ElasticDump extends TransportProcessor {
   constructor (input, output, options) {
@@ -37,8 +37,8 @@ class ElasticDump extends TransportProcessor {
         if (transform[0] === '@') {
           return doc => {
             const filePath = transform.slice(1).split('?')
-            const parsed = url.pathToFileURL(filePath[0])
-            return require(parsed.pathname)(doc, ElasticDump.getParams(filePath[1]))
+            const resolvedFilePath = path.resolve(process.cwd(), filePath[0])
+            return require(resolvedFilePath)(doc, ElasticDump.getParams(filePath[1]))
           }
         } else {
           const modificationScriptText = `(function(doc) { ${transform} })`


### PR DESCRIPTION
This approach now works in Windows.

Previous approach using `url.pathToFileURL` resolved into a format that `require()` doesn't like:

```
Fri, 06 Nov 2020 18:47:48 GMT | Will modify documents using these scripts: @./transforms/transformDocument.js
Fri, 06 Nov 2020 18:47:48 GMT | got 100 objects from source elasticsearch (offset: 0)
(node:22232) UnhandledPromiseRejectionWarning: Error: Cannot find module '/D:/tmp/elasticsearch-dump/transforms/transformDocument.js'
Require stack:
- D:\tmp\elasticsearch-dump\node_modules\elasticdump\elasticdump.js
- D:\tmp\elasticsearch-dump\node_modules\elasticdump\bin\elasticdump
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:831:15)
    at Function.Module._load (internal/modules/cjs/loader.js:687:27)
    at Module.require (internal/modules/cjs/loader.js:903:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at modificationScriptText (D:\tmp\elasticsearch-dump\node_modules\elasticdump\elasticdump.js:41:20)
    at D:\tmp\elasticsearch-dump\node_modules\elasticdump\lib\processor.js:77:15
    at Array.forEach (<anonymous>)
    at D:\tmp\elasticsearch-dump\node_modules\elasticdump\lib\processor.js:76:28
    at scrollResultSet (D:\tmp\elasticsearch-dump\node_modules\elasticdump\lib\transports\elasticsearch.js:872:16)
    at Request.<anonymous> (D:\tmp\elasticsearch-dump\node_modules\elasticdump\lib\transports\elasticsearch.js:314:9)
```