### PR TITLE
add option for specifying an S3 ACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,9 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     Enables encrypted uploads
 --s3SSEKMSKeyId
                     KMS Id to be used with aws:kms uploads                    
+--s3ACL
+                    S3 ACL: private | public-read | public-read-write | authenticated-read | aws-exec-read |
+                    bucket-owner-read | bucket-owner-full-control [default private]
 
 --retryDelayBase
                     The base number of milliseconds to use in the exponential backoff for operation retries. (s3)

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -56,6 +56,7 @@ const defaults = {
   s3Compress: false,
   s3ServerSideEncryption: null,
   s3SSEKMSKeyId: null,
+  s3ACL: null,
   fsCompress: false,
   awsIniFileName: null,
   sessionToken: null,

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -237,6 +237,9 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     Enables encrypted uploads
 --s3SSEKMSKeyId
                     KMS Id to be used with aws:kms uploads
+--s3ACL
+                    S3 ACL: private | public-read | public-read-write | authenticated-read | aws-exec-read |
+                    bucket-owner-read | bucket-owner-full-control [default private]
 --retryDelayBase
                     The base number of milliseconds to use in the exponential backoff for operation retries. (s3)
 --customBackoff

--- a/lib/splitters/s3StreamSplitter.js
+++ b/lib/splitters/s3StreamSplitter.js
@@ -32,7 +32,8 @@ class s3StreamSplitter extends StreamSplitter {
         Bucket: params.Bucket,
         Key,
         ServerSideEncryption: this._ctx.parent.options.s3ServerSideEncryption,
-        SSEKMSKeyId: this._ctx.parent.options.s3SSEKMSKeyId
+        SSEKMSKeyId: this._ctx.parent.options.s3SSEKMSKeyId,
+        ACL: this._ctx.parent.options.ACL
       })
     ).on('error', error => {
       this._ctx.parent.emit('error', error)

--- a/lib/transports/s3.js
+++ b/lib/transports/s3.js
@@ -116,7 +116,8 @@ class s3 extends base {
             Bucket,
             Key,
             ServerSideEncryption: this.parent.options.s3ServerSideEncryption,
-            SSEKMSKeyId: this.parent.options.s3SSEKMSKeyId
+            SSEKMSKeyId: this.parent.options.s3SSEKMSKeyId,
+            ACL: this.parent.options.s3ACL
           })
         ).on('error', error => {
           this.parent.emit('error', error)


### PR DESCRIPTION
The default canned ACL is private: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html but because we support other S3 endpoints like OpenStack Swift and OpenStack Ceph - I left it as null out of fear of breaking others.

I also believe this is the last param I need, and I'm sorry I didn't catch this yesterday. The use case for this is if you have an ES cluster in account A, and you to push the data into an s3 bucket in account B, you need to specify that the ACL be set to `bucket-owner-full-control` or the files will be owned by account A even though the bucket lives in account B.