### PR TITLE
fix --offset cause v8 oom

### DIFF
--- a/lib/transports/base.js
+++ b/lib/transports/base.js
@@ -60,9 +60,9 @@ class base {
         this.elementsToSkip--
       } else {
         this.bufferedData.push(elem)
+        this.localLineCounter++
       }
 
-      this.localLineCounter++
       this.lineCounter++
 
       if (this.localLineCounter === this.thisGetLimit) {


### PR DESCRIPTION
---
name: Bug report
about: Create a report to help us improve
title: "[--offset cause v8 OOM BUG]"
labels: bug
assignees: ''

---

**Context**
In order to help us troubleshoot issues with this project, you **must** provide the following details:

- ElasticDump version: `v6.66.1`
- Elasticsearch version: `v6.4.3`
- Node.js version *(note that nodejs v10+ is required for this tool)* : `v12.19.0`
- Full command you are having issue with (with inputs and outputs): 

   `node --max-old-space-size=4096 /data/esdump/node_modules/elasticdump/bin/elasticdump --input=/data/es-data/tkl.2020.json --offset=368300000  --limit=10000 --output=http://log-es02:9200/tkl_2020 >> ./tkl-2020.dump.log 2>&1 &`
- A data-set you can share publicly which reproduces the problem


**Describe the bug**

`my input file tkl.2020.json > 500GB, data count > 700 million.`

`When the offset parameter is used, V8 will report OOM error.`

`No matter how big you add --max-old-space-size, it will still be OOM.`

`When I look at the code, I find that the __setupStreamEvents function of base.js has a loop-point in its logic when handling the --offset argument. The *this.localLineCounter* should not be increased when a given line is skipped. This will result in this.locallinecounter never being equal to this.thisGetLimit, which will result in this.completeBatch never being called, and will result in this.bufferedData growing unlimitedly. so OOM`


`tac tkl-2020.dump.log | more`

```json
15: 0x138f6ad  [node]
14: 0x9f1d76  [node]
13: 0xaf3da0 node::StringBytes::Encode(v8::Isolate*, char const*, unsigned long, node::encoding, v8::Local<v8::Value>*) [node]
12: 0xbadd9f v8::String::NewFromUtf8(v8::Isolate*, char const*, v8::NewStringType, int) [node]
11: 0xd31f8d v8::internal::Factory::NewStringFromUtf8(v8::internal::Vector<char const> const&, v8::internal::AllocationType) [node]
10: 0xd317cc v8::internal::Factory::NewRawOneByteString(int, v8::internal::AllocationType) [node]
 9: 0xd6392c v8::internal::Heap::AllocateRawWithRetryOrFail(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::Allo
cationAlignment) [node]
 8: 0xd60e75 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
 7: 0xd5ffc5 v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::GCCallbackFlags) [node]
 6: 0xd53706 v8::internal::Heap::RecomputeLimits(v8::internal::GarbageCollector) [node]
 5: 0xd53075  [node]
 4: 0xb95df9 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [node]
 3: 0xb95a7e v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [node]
 2: 0xa1804c node::OnFatalError(char const*, char const*) [node]
 1: 0xa17c40 node::Abort() [node]
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory

    2: /* anonymous */ [0x1625f138e4a9] [/data/esdump/node_modules/JSONStream/index.js:~20] [pc=0x20bb025050f2](this=0x1625f1390071 <Stream map =
 0x119013c0106...
    1: write [0x37d0f98af4f1] [/data/esdump/node_modules/jsonparse/jsonparse.js:~127] [pc=0x20bb025066a5](this=0x1625f138e3d9 <Parser map = 0x156
00eabb219>,0x3c8a45dc8631 <Uint8Array map = 0x15600eaa5a09>)
Security context: 0x3129e50808d1 <JSObject>
    0: ExitFrame [pc: 0x138f6ad]

==== JS stack trace =========================================

<--- JS stacktrace --->

 i[5081:0x3215960]  8945721 ms: Mark-sweep 2047.3 (2051.2) -> 2047.0 (2051.2) MB, 1554.2 / 0.0 ms  (+ 76.6 ms in 20 steps since start of marking,
 biggest step 13.7 ms, walltime since start of marking 1645 ms) (average mu = 0.103, current mu = 0.012) allocat[5081:0x3215960]  8947847 ms: Mar
k-sweep 2047.2 (2051.2) -> 2046.7 (2051.4) MB, 2123.2 / 0.0 ms  (+ 0.0 ms in 4 steps since start of marking, biggest step 0.0 ms, walltime since 
start of marking 2126 ms) (average mu = 0.048, current mu = 0.001) finalize i
<--- Last few GCs --->

Sun, 21 Mar 2021 08:26:17 GMT |   * Using an offset doesn't guarantee that the offset rows have already been written, please refer to the HELP te
xt.
Sun, 21 Mar 2021 08:26:17 GMT | Warning: offsetting 368300000 rows.
Sun, 21 Mar 2021 08:26:17 GMT | starting dump`
```

**To Reproduce**
Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

**Current behavior**
Describe what's happening now.

**Expected behavior**
A clear and concise description of what you expected to happen.

**Screenshots**
If applicable, add screenshots to help explain your problem.

**Additional context**
Add any other context about the problem here.

> A good bug report shouldn't leave others needing to chase you up for more information. Please try to be as detailed as possible in your report. What is your environment? What was the url? What steps will reproduce the issue? What OS experience the problem? All these details will help to fix any potential bugs as soon as possible.


