### PR TITLE
fixing syntax error and providing usage example for awsUrlRegex flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,8 +454,8 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     Sets the AWS region that the signature will be generated for
                     (default: calculated from hostname or host)
 --awsUrlRegex
-                    Regular expression that defined valied AWS urls that should be signed
-                    (default: ^https?:\\.*.amazonaws.com.*$)
+                    Regular expression that defines AWS Elastic Search Clusters' urls that should be signed - for example AWS Elastic Search Custom Domains
+                    (default: ^https?:\/.*.amazonaws.com.*$)
 --support-big-int   
                     Support big integer numbers
 --big-int-fields   


### PR DESCRIPTION
Originally I was going to file a bug request but given the context of the fix I decided to update the documentation I wasn't able to understand myself and spent a lot of time debugging to figure out.

When using custom domains for the AWS ESearch cluster without the --awsUrlRegex one simply gets:

```
Fri, 09 Jul 2021 02:49:07 GMT | starting dump
Fri, 09 Jul 2021 02:49:08 GMT | Error Emitted => Similar to 403 Forbidden, but specifically for use when authentication is required and has failed or has not yet been provided.
Fri, 09 Jul 2021 02:49:08 GMT | Error Emitted => Similar to 403 Forbidden, but specifically for use when authentication is required and has failed or has not yet been provided.
Fri, 09 Jul 2021 02:49:08 GMT | Total Writes: 0
Fri, 09 Jul 2021 02:49:08 GMT | dump ended with error (get phase) => UNAUTHORIZED: Similar to 403 Forbidden, but specifically for use when authentication is required and has failed or has not yet been provided.
```

Which is a generic error thrown AFTER the HTTP request has been sent making things rather hard to troubleshoot since it doesn't provide any context as to which part of the request is failing.

I literally had to "GUESS" that using the cluster's DEFAULT url would work after looking through the code and finding lib/aws4signer.js which gave me a hint with the regex *.amazonaws.com. 

Not easy to troubleshoot at all.

The regular expression format in the Document was incorrect as well as it was using \\ rather than \/