### PR TITLE
Add size option to multielasticdump

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ The limited option set includes:
 - `timeout`: `null`,
 - `limit`:      `100`,
 - `offset`:     `0`,
+- `size`:       `-1`,
 - `direction`:   `dump`,
 - `ignoreType`:   ``
 - `includeType`:   ``

--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -39,6 +39,7 @@ const defaults = {
   timeout: null,
   limit: 100,
   offset: 0,
+  size: -1,
   direction: 'dump', // default to dump
   'support-big-int': false,
   'big-int-fields': '',
@@ -403,6 +404,7 @@ const dump = () => {
       `--scrollTime=${options.scrollTime}`,
       `--limit=${options.limit}`,
       `--offset=${options.offset}`,
+      `--size=${options.size}`,
       `--searchBody=${options.searchBody}`,
       `--searchWithTemplate=${options.searchWithTemplate}`,
       `--prefix=${options.prefix}`,
@@ -544,6 +546,7 @@ const load = () => {
       `--timeout=${options.timeout}`,
       `--limit=${options.limit}`,
       `--offset=${options.offset}`,
+      `--size=${options.size}`,
       `--prefix=${options.prefix}`,
       `--suffix=${options.suffix}`,
       `--support-big-int=${options['support-big-int']}`,


### PR DESCRIPTION
`size` can be used to limit the number of documents dumped by index.