### PR TITLE
Build docker image from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM node:14-buster-slim
 LABEL maintainer="ferronrsmith@gmail.com"
-ARG ES_DUMP_VER
-ENV ES_DUMP_VER=${ES_DUMP_VER:-latest}
 ENV NODE_ENV production
+WORKDIR /app
 
-RUN npm install elasticdump@${ES_DUMP_VER} -g
+COPY . .
+RUN npm install --production -g
 
-COPY docker-entrypoint.sh /usr/local/bin/
+RUN rm /usr/local/bin/docker-entrypoint.sh && \
+  ln -s /app/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 


### PR DESCRIPTION
Use the local source instead of npm package repository to build the elasticsearch-dump docker image.

Not sure if that's something that you want, but I find it more usefull when working with and testing forks and it feels more like what I would expect when I build a dockerfile in a source repository.