### PR TITLE
Set ESVersion to 7 for opensearch

### DIFF
--- a/lib/transports/__es__/_base.js
+++ b/lib/transports/__es__/_base.js
@@ -74,6 +74,10 @@ class Base {
         if (response.version) {
           this.ESFullversion = response.version.number
           this.ESversion = response.version.number.split('.')[0]
+          if (response.version.distribution && response.version.distribution === 'opensearch') {
+            this.ESversion = 7
+            this.parent.emit('debug', `distribution is opensearch, assuming major version: ${this.ESversion}`)
+          }
           this.parent.emit('debug', `discovered elasticsearch ${prefix} major version: ${this.ESversion}`)
         } else {
           this.ESversion = 5


### PR DESCRIPTION
Fixes #832 

Opensearch is compatible with the 7.x Elasticsearch API so set the ESVersion to that when an Opensearch cluster is detected.