### PR TITLE
Fix parent access in s3 stream splitter

### DIFF
--- a/lib/splitters/s3StreamSplitter.js
+++ b/lib/splitters/s3StreamSplitter.js
@@ -34,7 +34,7 @@ class s3StreamSplitter extends StreamSplitter {
         ServerSideEncryption: this._ctx.parent.options.s3ServerSideEncryption,
         SSEKMSKeyId: this._ctx.parent.options.s3SSEKMSKeyId,
         ACL: this._ctx.parent.options.ACL,
-        StorageClass: this.parent.options.s3StorageClass
+        StorageClass: this._ctx.parent.options.s3StorageClass
       })
     ).on('error', error => {
       this._ctx.parent.emit('error', error)


### PR DESCRIPTION
The code was accessing the parent directly without passing through the _ctx object when getting the storage class option, which resulted in an error when executing a dump to s3