### PR TITLE
Fix dump of indexes having `%`

### DIFF
--- a/lib/ioHelper.js
+++ b/lib/ioHelper.js
@@ -1,4 +1,4 @@
-const { isUrl, isCsvUrl } = require('./is-url')
+const { isUrl, isCsvUrl, encodeURIOnce } = require('./is-url')
 const addAuth = require('./add-auth')
 const path = require('path')
 const s3urls = require('s3urls')
@@ -11,7 +11,7 @@ const getIo = (elasticdump, type) => {
       if (elasticdump.options.httpAuthFile) {
         elasticdump.options[type] = addAuth(elasticdump.options[type], elasticdump.options.httpAuthFile)
       }
-    } else if (s3urls.valid(elasticdump.options[type])) {
+    } else if (s3urls.valid(encodeURIOnce(elasticdump.options[type]))) {
       elasticdump[`${type}Type`] = 's3'
     } else if (isCsvUrl(elasticdump.options[type])) {
       elasticdump[`${type}Type`] = 'csv'

--- a/lib/is-url.js
+++ b/lib/is-url.js
@@ -6,7 +6,7 @@ const csvUrlRegex = /^(csv:\/\/)(.+)$/
 // should not start with http:// or https:// and urls should.
 const isUrl = (url) => {
   if (!url) return false
-  url = url.toString()
+  url = decodeURIComponent(encodeURIOnce(url.toString()))
   return url.indexOf('http://') === 0 || url.indexOf('https://') === 0
 }
 
@@ -32,8 +32,25 @@ const isCsvUrl = (filePath) => {
   return !!matches
 }
 
+const encodeURIOnce = (uri) => {
+  let isEncoded
+
+  try {
+    isEncoded = uri !== decodeURIComponent(uri)
+  } catch (error) {
+    if (error instanceof URIError) {
+      isEncoded = false
+    } else {
+      throw error
+    }
+  }
+
+  return isEncoded ? uri : encodeURIComponent(uri)
+}
+
 module.exports = {
   isUrl,
   isCsvUrl,
-  fromCsvUrl
+  fromCsvUrl,
+  encodeURIOnce
 }

--- a/test/is-url.tests.js
+++ b/test/is-url.tests.js
@@ -1,5 +1,5 @@
-const { isUrl } = require('../lib/is-url')
-var should = require('should') // eslint-disable-line
+const { isUrl, encodeURIOnce } = require('../lib/is-url')
+require('should')
 
 describe('is-url', () => {
   it('returns true if url starts with http://', () => {
@@ -19,5 +19,26 @@ describe('is-url', () => {
   })
   it('returns false for unix file path', () => {
     isUrl('/some/unix/path').should.equal(false)
+  })
+  it('returns true if url is encoded', () => {
+    isUrl('http%3A%2F%2Fgithub.com%2Fkuzzleio%2Fkuzzle').should.equal(true)
+  })
+})
+
+describe('encodeURIOnce', () => {
+  const decodedURI = 'http://github.com/kuzzleio/kuzzle'
+  const encodedURI = 'http%3A%2F%2Fgithub.com%2Fkuzzleio%2Fkuzzle'
+
+  it('returns encoded URI if not encoded', () => {
+    encodeURIOnce(decodedURI).should.equal(encodedURI)
+  })
+  it('returns same encoded URI if already encoded', () => {
+    encodeURIOnce(encodedURI).should.equal(encodedURI)
+  })
+  it('returns encoded partial URI component', () => {
+    encodeURIOnce('%kuzzle').should.equal('%25kuzzle')
+  })
+  it('returns same encoded partial URI component if already encoded', () => {
+    encodeURIOnce('%25kuzzle').should.equal('%25kuzzle')
   })
 })


### PR DESCRIPTION
## Description

This PR fix dumping of indexes containing `%`. (Example `%kuzzle.users`)

The bug was caused by the `s3urls` package trying to decode the URL and failing with a `URI Malformed` error because it contains the URL escaping character (`%`) but no escape sequence after it.

<details><summary>Error stacktrace</summary>

```
▶ multielasticdump --direction dump --input http://localhost:9200 --output ./dump
Sat, 15 Jan 2022 17:30:18 GMT | We are performing : dump
Sat, 15 Jan 2022 17:30:18 GMT | options: {"debug":true,"parallel":12,"match":"^.*$","order":"asc","input":"http://localhost:9200","output":"./dump","scrollId":null,"scrollTime":"10m","scroll-with-post":false,"timeout":null,"limit":100,"offset":0,"size":-1,"direction":"dump","support-big-int":false,"big-int-fields":"","ignoreAnalyzer":true,"ignoreChildError":false,"ignoreData":false,"ignoreMapping":false,"ignoreSettings":false,"ignoreTemplate":false,"ignoreAlias":true,"ignoreType":[],"includeType":null,"interval":1000,"delete":false,"prefix":"","suffix":"","transform":null,"headers":null,"searchBody":null,"searchWithTemplate":null,"cert":null,"key":null,"pass":null,"ca":null,"tlsAuth":false,"input-cert":null,"input-key":null,"input-pass":null,"input-ca":null,"output-cert":null,"output-key":null,"output-pass":null,"output-ca":null,"httpAuthFile":null,"concurrency":1,"carryoverConcurrencyCount":true,"intervalCap":5,"concurrencyInterval":5000,"overwrite":false,"fsCompress":false,"awsChain":false,"awsAccessKeyId":null,"awsSecretAccessKey":null,"awsIniFileProfile":null,"awsService":null,"awsRegion":null,"s3AccessKeyId":null,"s3SecretAccessKey":null,"s3Region":null,"s3Endpoint":null,"s3SSLEnabled":true,"s3ForcePathStyle":false,"s3Compress":false,"s3ServerSideEncryption":null,"s3SSEKMSKeyId":null,"s3ACL":null,"quiet":false}
Sat, 15 Jan 2022 17:30:18 GMT [debug] | GET /_aliases
Sat, 15 Jan 2022 17:30:18 GMT [debug] | GET /_aliases -> 200 OK
Sat, 15 Jan 2022 17:30:18 GMT | dumping http://localhost:9200 to ./dump/%kuzzle.api-keys.template.json
Sat, 15 Jan 2022 17:30:18 GMT [debug] | fork: /Users/stephane/.nvm/versions/node/v14.18.1/lib/node_modules/elasticdump/bin/elasticdump --type=template,--input=http://localhost:9200,--output=./dump/%kuzzle.api-keys.template.json,--headers=null,--cert=null,--key=null,--pass=null,--ca=null,--tlsAuth=false,--input-cert=null,--input-key=null,--input-pass=null,--input-ca=null,--output-cert=null,--output-key=null,--output-pass=null,--output-ca=null,--httpAuthFile=null,--concurrency=1,--carryoverConcurrencyCount=true,--intervalCap=5,--concurrencyInterval=5000,--overwrite=false,--fsCompress=false,--awsChain=false,--awsAccessKeyId=null,--awsSecretAccessKey=null,--awsIniFileProfile=null,--awsService=null,--awsRegion=null,--s3AccessKeyId=null,--s3SecretAccessKey=null,--s3Region=null,--s3Endpoint=null,--s3SSLEnabled=true,--s3ForcePathStyle=false,--s3Compress=false,--s3ServerSideEncryption=null,--s3SSEKMSKeyId=null,--s3ACL=null,--quiet=false,--scroll-with-post=false
/Users/stephane/.nvm/versions/node/v14.18.1/lib/node_modules/elasticdump/node_modules/s3urls/index.js:7
    uri.pathname = decodeURIComponent(uri.pathname);
                   ^

URIError: URI malformed
    at decodeURIComponent (<anonymous>)
    at Object.fromUrl (/Users/stephane/.nvm/versions/node/v14.18.1/lib/node_modules/elasticdump/node_modules/s3urls/index.js:7:20)
    at Object.valid (/Users/stephane/.nvm/versions/node/v14.18.1/lib/node_modules/elasticdump/node_modules/s3urls/index.js:51:25)
    at getIo (/Users/stephane/.nvm/versions/node/v14.18.1/lib/node_modules/elasticdump/lib/ioHelper.js:14:23)
    at new ElasticDump (/Users/stephane/.nvm/versions/node/v14.18.1/lib/node_modules/elasticdump/elasticdump.js:36:5)
    at Object.<anonymous> (/Users/stephane/.nvm/versions/node/v14.18.1/lib/node_modules/elasticdump/bin/elasticdump:156:18)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
Sat, 15 Jan 2022 17:30:19 GMT | Error: CHILD PROCESS EXITED WITH ERROR.  Stopping process
```

</details>

### Other changes

 - support encoded URLs detection for `isUrl` method

PS: Thanks you guys for this very useful project :+1: 