### PR TITLE
multielasticdump: Fix bug with double // in s3 keys

### DIFF
--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -337,6 +337,7 @@ if (options.direction === 'load') {
       .replace(`.settings.${fileExt}`, '')
       .replace(`.template.${fileExt}`, '')
       .replace(`.${fileExt}`, ''))
+      .replace('/', '')
       .filter(item => matchRegExp.test(item))
     matchedIndexes = _.uniq(matchedIndexes)
     args.log('info', `list of indexes${JSON.stringify(matchedIndexes)}`)


### PR DESCRIPTION
This fixes a bug in which multielasticdump inserts an extra `/` in S3 keys when loading from S3, which prevents elasticdump from finding the correct files. `/` is not a valid character in elastic index names. Note that this only behaves correctly when the `--input` s3 path does _not_ have a trailing `/`.

S3 handles keys slightly differently from how filesystems handle directory separators. In S3 `a//b` is a valid object key and distinct from `a/b`.

To give an example, suppose I have my dump files named like `s3://my_bucket/my_dumps/dump_X/index.json`.

If I use `--input=s3://my_bucket/my_dumps/dump_X`, then the files returned from `listFiles` will each have a leading `/` and `generatePath` will add a second `/` next to it. But if I use `--input=s3://my_bucket/my_dumps/dump_X/`, then the files returned from listFiles will (correctly) lack a leading `/` but `generatePath` will add a second `/` next to the trailing `/` from `--input`.

This solution strips the extra leading `/` before it can be doubled.