### PR TITLE
Add csvIncludeEndRowDelimiter option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 node_modules/*
 /nbproject/private/
 package-lock.json
+
+# Intellij
+.idea/

--- a/README.md
+++ b/README.md
@@ -612,6 +612,9 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     Name of the column to extract the record type from
                     When exporting to CSV this column can be used to override the default type (@type) column name
                     (default : null)   
+--csvIncludeEndRowDelimiter        
+                    Set to true to include a row delimiter at the end of the csv
+                    (default : false)
 --force-os-version   
                     Forces the OpenSearch version used by elasticsearch-dump.
                     (default: 7.10.2)                       

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -131,6 +131,7 @@ const defaults = {
   csvDiscardUnmappedColumns: false,
   csvQuoteChar: '"',
   csvEscapeChar: '"',
+  csvIncludeEndRowDelimiter: false,
 
   // opensearch compatability
   'force-os-version': '7.10.2'

--- a/lib/transports/csv.js
+++ b/lib/transports/csv.js
@@ -125,7 +125,8 @@ class csv extends base {
       delimiter: this.parent.options.csvDelimiter,
       rowDelimiter: this.parent.options.csvRowDelimiter,
       quote: this.parent.options.csvQuoteChar,
-      escape: this.parent.options.csvEscapeChar
+      escape: this.parent.options.csvEscapeChar,
+      includeEndRowDelimiter: this.parent.options.csvIncludeEndRowDelimiter
     })
 
     // simple flat for csv


### PR DESCRIPTION
Hello,

I've included a new option to choose to add or not a row delimiter at the end of the CSV.
[It's basically just an option from `fast-csv` to set](https://c2fo.github.io/fast-csv/docs/formatting/options/#includeendrowdelimiter).

My use case is to dump data from Elastic and from another store (both CSV formatted) then to perform a `diff` on them.
And of course, `diff` is complaining when the last row delimiter is different.

Feel free to ask is something is not clear... thank you!