### PR TITLE
Prevent "Cannot read property 'message' of undefined" error

### DIFF
--- a/lib/transports/__es__/_analyzer.js
+++ b/lib/transports/__es__/_analyzer.js
@@ -82,12 +82,11 @@ class Analyzer {
         this.baseRequest(esRequest, (err, response) => { // ensure the index exists
           err = this.handleError(err, response)
 
-          if (this.parent.options['skip-existing'] && /resource_already_exists_exception/.test(err.message)) {
-            this.parent.emit('debug', 'resource_already_exists_exception thrown & skip-existing enabled')
-            return callback(null, 0)
-          }
-
           if (err) {
+            if (this.parent.options['skip-existing'] && /resource_already_exists_exception/.test(err.message)) {
+              this.parent.emit('debug', 'resource_already_exists_exception thrown & skip-existing enabled')
+              return callback(null, 0)
+            }
             return callback(err, [])
           }
 


### PR DESCRIPTION
When creating analyzers while using the --skip-existing option, I ran into the following error after deleting all indices and trying to import an analyzer from a file input:

```
(node:116787) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'message' of undefined
    at Request.baseRequest (/usr/local/lib/node_modules/elasticdump/lib/transports/__es__/_analyzer.js:85:100)
    at Request._callback (/usr/local/lib/node_modules/elasticdump/node_modules/lodash/lodash.js:10118:25)
    at Request.requestRetryReply [as reply] (/usr/local/lib/node_modules/elasticdump/node_modules/requestretry/index.js:151:19)
    at Request.<anonymous> (/usr/local/lib/node_modules/elasticdump/node_modules/requestretry/index.js:192:10)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:116787) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
```

This should prevent that error from occurring as it'll check if err is even defined first.

I'm not a nodejs expert or anything, nor am I familiar with nodejs code style best practices, so let me know if this is not the best way to fix the issue.