### PR TITLE
Add index type to dump and load whole index metadata (alias, mapping,…

### DIFF
--- a/lib/transports/__es__/_index.js
+++ b/lib/transports/__es__/_index.js
@@ -1,0 +1,73 @@
+const jsonParser = require('../../jsonparser.js')
+const aws4signer = require('../../aws4signer')
+const async = require('async')
+const _ = require('lodash')
+
+class Index {
+  getIndex (limit, offset, callback) {
+    if (this.gotIndex === true) {
+      callback(null, [])
+    } else {
+      const esRequest = {
+        url: `${this.base.url}/`,
+        method: 'GET'
+      }
+      aws4signer(esRequest, this.parent).then(() => {
+        this.baseRequest(esRequest, (err, response) => {
+          this.gotIndex = true
+          const payload = []
+
+          err = this.handleError(err, response)
+          if (err) {
+            return callback(err, [])
+          }
+
+          payload.push(jsonParser.parse(response.body))
+          callback(err, payload)
+        })
+      }).catch(callback)
+    }
+  }
+
+  setIndex (data, limit, offset, callback) {
+    if (this.haveSetIndex === true || data.length === 0) {
+      return callback(null, 0)
+    }
+
+    try {
+      data = data[0]
+    } catch (e) {
+      return callback(e)
+    }
+
+    let writes = 0
+
+    async.forEachOf(data, (index, name, cb) => {
+      if (_.isEmpty(index) || _.isEmpty(name)) return cb()
+
+      index = _.omit(index, this.settingsExclude)
+
+      const esRequest = {
+        url: this.base.url,
+        method: 'PUT',
+        body: jsonParser.stringify(index)
+      }
+      aws4signer(esRequest, this.parent).then(() => {
+        this.baseRequest(esRequest, (err, response) => { // ensure the index exists
+          err = this.handleError(err, response)
+          if (err) {
+            return cb(err, [])
+          }
+          writes++
+          return cb()
+        })
+      }).catch(cb)
+    }, err => {
+      if (err) { return callback(err) }
+      this.haveSetIndex = true
+      return callback(null, writes)
+    })
+  }
+}
+
+module.exports = Index

--- a/lib/transports/__es__/index.js
+++ b/lib/transports/__es__/index.js
@@ -2,6 +2,7 @@ module.exports = {
   Base: require('./_base'),
   Alias: require('./_alias'),
   Analyzer: require('./_analyzer'),
+  Index: require('./_index'),
   Mapping: require('./_mapping'),
   Policy: require('./_policy'),
   Setting: require('./_setting'),

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -10,6 +10,7 @@ const {
   Analyzer,
   Base,
   Data,
+  Index,
   Mapping,
   Policy,
   Setting,
@@ -17,7 +18,7 @@ const {
   Script
 } = require('./__es__')
 
-class elasticsearch extends Many(Base, Alias, Analyzer, Mapping, Policy, Setting, Template, Script, Data) {
+class elasticsearch extends Many(Base, Alias, Analyzer, Index, Mapping, Policy, Setting, Template, Script, Data) {
   constructor (parent, url, options) {
     super()
     this.base = parseBaseURL(url, options)
@@ -77,6 +78,8 @@ class elasticsearch extends Many(Base, Alias, Analyzer, Mapping, Policy, Setting
 
       if (type === 'data') {
         this.getData(limit, offset, callback)
+      } else if (type === 'index') {
+        this.getIndex(limit, offset, callback)
       } else if (type === 'mapping') {
         this.getMapping(limit, offset, callback)
       } else if (type === 'analyzer' || type === 'settings') {
@@ -120,6 +123,8 @@ class elasticsearch extends Many(Base, Alias, Analyzer, Mapping, Policy, Setting
 
       if (type === 'data') {
         this.setData(data, limit, offset, callback)
+      } else if (type === 'index') {
+        this.setIndex(data, limit, offset, callback)
       } else if (type === 'mapping') {
         this.setMapping(data, limit, offset, callback)
       } else if (type === 'analyzer') {

--- a/test/test.js
+++ b/test/test.js
@@ -563,6 +563,38 @@ describe('ELASTICDUMP', () => {
       })
     })
 
+    it('can set and get whole index', function (done) {
+      this.timeout(testTimeout)
+      const options = {
+        limit: 100,
+        offset: 0,
+        debug: false,
+        type: 'index',
+        input: baseUrl + '/source_index',
+        output: baseUrl + '/destination_index',
+        scrollTime: '10m'
+      }
+
+      const dumper = new Elasticdump(options.input, options.output, options)
+
+      dumper.dump(() => {
+        const url = baseUrl + '/destination_index/_search'
+        request.get(url, (err, response, body) => {
+          should.not.exist(err)
+          body = JSON.parse(body)
+          getTotal(body).should.equal(0)
+          const url = baseUrl + '/destination_index/'
+          request.get(url, (err, response, body) => {
+            should.not.exist(err)
+            body = JSON.parse(body)
+            body.destination_index.settings.index.analysis.analyzer.content.type.should.equal('custom')
+            jq.value(body, 'destination_index.mappings..properties.key.type').should.be.oneOf(['string', 'text'])
+            done()
+          })
+        })
+      })
+    })
+
     it('can set and get template', function (done) {
       this.timeout(testTimeout)
 


### PR DESCRIPTION
I hit an issue with trying to dump an index with `index.sort` settings. `sort` requires a mapping with the sorted field, but at the settings load, there's still no mapping and inverting both will create the index without the right settings.

This PR add a new dump/load type `index` which allow to dump all index metadata (As seen in `GET /<index>`) and re-load the index from this.