### PR TITLE
Ignore setting settings.index.resize

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -25,7 +25,13 @@ class elasticsearch extends Many(Base, Alias, Analyzer, Mapping, Policy, Setting
     this.parent = parent
     this.type = parent.options.type
     this.lastScrollId = null
-    this.settingsExclude = ['settings.index.version', 'settings.index.creation_date', 'settings.index.uuid', 'settings.index.provided_name']
+    this.settingsExclude = [
+      'settings.index.version',
+      'settings.index.creation_date',
+      'settings.index.uuid',
+      'settings.index.provided_name',
+      'settings.index.resize'
+    ]
     /**
      * Note that _parent, has been deprecated since ES 6.0
      * Note that _timestamp & _ttl have been deprecated since ES 5.0


### PR DESCRIPTION
This setting appears when an index has been resized in the past, however if trying to restore a dump it fails since this cannot be set by the user.