### PR TITLE
Add prefix and suffix to common args

### DIFF
--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -167,6 +167,8 @@ const commonParams = [
   `--s3SSEKMSKeyId=${options.s3SSEKMSKeyId}`,
   `--s3ACL=${options.s3ACL}`,
   `--quiet=${options.quiet}`,
+  `--prefix=${options.prefix}`,
+  `--suffix=${options.suffix}`,
   `--scroll-with-post=${options['scroll-with-post']}`
 ]
 
@@ -542,8 +544,6 @@ const dump = () => {
       `--size=${options.size}`,
       `--searchBody=${options.searchBody}`,
       `--searchWithTemplate=${options.searchWithTemplate}`,
-      `--prefix=${options.prefix}`,
-      `--suffix=${options.suffix}`,
       `--support-big-int=${options['support-big-int']}`,
       `--big-int-fields=${options['big-int-fields']}`
     ].concat(_transform))
@@ -690,8 +690,6 @@ const load = () => {
       `--limit=${options.limit}`,
       `--offset=${options.offset}`,
       `--size=${options.size}`,
-      `--prefix=${options.prefix}`,
-      `--suffix=${options.suffix}`,
       `--support-big-int=${options['support-big-int']}`,
       `--big-int-fields=${options['big-int-fields']}`
     ].concat(_transform))


### PR DESCRIPTION
This quick patch on my machine allowed me to import from multielasticdump into new indices with both a prefix and a suffix.

This change is broad and affects dump and load but does not appear to negatively affect dumping or loading from dumps from this code

Open to all feedback, specifically on how generic this approach is

fixes 974

```
green open mdt3sourcemoose                       a-M0xYDoQtaN0_P2CUiMVQ 1 1  733    0 656.9kb 328.4kb
green open mdt3sourcegoose               vpQMsgGES2WPXPg_qbWyyQ 1 1   52    0  89.6kb  44.8kb
green open mdtsourcecaboosemdt              QhGrfPDXRMSs0Wea4W8kiQ 1 1    0    0    450b    225b
green open mdtmoddumpmdtsourcemoosemdt           GEovgei6Q56PCefJg6rX3w 1 1    0    0    450b    225b
green open mdtmoddumpmdtsourcegoosemdt   uywzHmq8Sxizs-IoeI5P-w 1 1    0    0    450b    225b
green open mdtmoddumpmdtsourcecaboosemdt    EPSM5UeeThSExUGR2FQoJg 1 1    0    0    450b    225b
green open sourcemoose                           vO9UxDuPSCyBVh-wB09Flg 1 1  735 3287   1.6mb   880kb
green open mdt2sourcegoosemdt2           hCni_YQcSHuOWf3EAFjqvA 1 1    0    0    450b    225b
green open mdt42sourcegoose              -rhCk4h3QQeePTxuqZ4jPw 1 1   52    0  89.6kb  44.8kb
green open mdtmoddumpsourcegoose         MYbOE8kpR9exb6ch6UmT8A 1 1   53    0  89.6kb  44.8kb
green open mdt2sourcecaboosemdt2            3GPRwATFQy226p6WU-RVlA 1 1    0    0    450b    225b
green open mdt42sourcemoose                      f9M8So7QRmm2QU_ML4N1hw 1 1  733    0 656.9kb 328.4kb
green open mdtmoddumpmdt42sourcemoose            lOFdwSOdRVuRqH2aWrXTNQ 1 1  733    0 656.4kb 328.2kb
green open mdtmoddumpmdt42sourcegoose    BwCcCx-STTeBAS9_YMTGnA 1 1   52    0  89.2kb  44.6kb
green open mdtmoddumpmdt2sourcemoosemdt2         yRCyxHeDR9-FbdEOQhiOfw 1 1    0    0    450b    225b
green open mdtmoddumpmdt2sourcecaboosemdt2  fnzmMDSARxqPQJ7DwshvvA 1 1    0    0    450b    225b
green open mdtsourcegoosemdt             5vX4dcdzTJW-EDyvAs_kgw 1 1    0    0    450b    225b
green open mdtmoddumpsourcemoose                 bSxESe9oRBqE6vyP3qJoXg 1 1  735    0 655.5kb 327.7kb
green open sourcecaboose                    j6hMAbuXSpKQXOKE2Kvz3g 1 1 1199  421   4.4mb   2.1mb
green open mdtmoddumpmdt42sourcecaboose     A3aiK5HrQqi2Qaa4V0Umng 1 1 1198    0   3.7mb   1.8mb
green open mdtsourcemoosemdt                     N9WZnCj2TW20lVJL7cfm6g 1 1    0    0    450b    225b
green open mdtmoddumpmdt3sourcegoose     VuNmrNwtSs61eUch4EvbKQ 1 1   52    0  89.2kb  44.6kb
green open mdtmoddumpmdt3sourcecaboose      0-ayLS_UR1qkoe-GqzQSqQ 1 1 1198    0   3.7mb   1.8mb
green open mdtmoddumpmdt3sourcemoose             R_8LzO-SS4GZ75qBnYS52w 1 1  733    0 656.4kb 328.2kb
green open mdtmoddumpsourcecaboose          eJbgPlewT3SWigxtDztfTg 1 1 1199    0   3.6mb   1.8mb
green open sourcegoose                   PGS5-83_SSii3jbsHvNjfQ 1 1   53    1 115.5kb  57.7kb
green open mdt2sourcemoosemdt2                   A8jxKfZjQ9yL0MxiaNMogQ 1 1    0    0    450b    225b
green open mdt3sourcecaboose                HLUajRYaThCxFn0T6ge2sg 1 1 1198    0   3.6mb   1.8mb
green open mdt42sourcecaboose               obYowxdFRhq1J7jk-lGv1Q 1 1 1198    0   3.7mb   1.9mb
green open mdtmoddumpmdt2sourcegoosemdt2 OnU33Z4iRlyERvUdFv_0aw 1 1    0    0    450b    225b
```