### PR TITLE
Exclude type from getMapping to support migration between ES versions

### DIFF
--- a/lib/transports/__es__/_mapping.js
+++ b/lib/transports/__es__/_mapping.js
@@ -7,8 +7,12 @@ class Mapping {
     if (this.gotMapping === true) {
       callback(null, [])
     } else {
+      let url = `${this.base.url}/_mapping`
+      if (this.ESversion < 7) {
+         url += `?include_type_name=false`
+      }
       const esRequest = {
-        url: `${this.base.url}/_mapping`,
+        url,
         method: 'GET'
       }
       aws4signer(esRequest, this.parent).then(() => {


### PR DESCRIPTION
Should help when migrating from v6.x to higher versions, since exporting the type will not work on v8.x.
this of course could be implemented with parameters like in setMapping.