### PR TITLE
index settings: ignore initial_recovery

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -30,7 +30,8 @@ class elasticsearch extends Many(Base, Alias, Analyzer, Mapping, Policy, Setting
       'settings.index.creation_date',
       'settings.index.uuid',
       'settings.index.provided_name',
-      'settings.index.resize'
+      'settings.index.resize',
+      'settings.index.routing.allocation.initial_recovery',
     ]
     /**
      * Note that _parent, has been deprecated since ES 6.0


### PR DESCRIPTION
Same as https://github.com/elasticsearch-dump/elasticsearch-dump/pull/972

This settings seems to appear after split/recovery operations, and can't be imported.