### PR TITLE
Bump Node.js in Dockerfile to v20 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-buster-slim
+FROM node:20-bookworm-slim
 LABEL maintainer="ferronrsmith@gmail.com"
 ARG ES_DUMP_VER
 ARG TARGETPLATFORM

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -1,4 +1,4 @@
-FROM node:14-buster-slim
+FROM node:20-bookworm-slim
 LABEL maintainer="ferronrsmith@gmail.com"
 ENV NODE_ENV production
 WORKDIR /app


### PR DESCRIPTION
The Dockerfile still uses Node.js v14 LTS. The support for this version ended on the 30th of April 2023. Node.js v20 is still supported.