### PR TITLE
Print out Scroll ID

### DIFF
--- a/lib/transports/__es__/_data.js
+++ b/lib/transports/__es__/_data.js
@@ -62,7 +62,7 @@ class Data {
             err = new Error('Unable to obtain scrollId; This tends to indicate an error with your index(es)')
             return callback(err, [])
           } else {
-            this.parent.emit('debug', `lastScrollId: ${this.lastScrollId}`)
+            console.log(`Scroll ID: ${self.lastScrollId}`)
           }
 
           // hits.total is now an object in the search response

--- a/lib/transports/__es__/_helpers.js
+++ b/lib/transports/__es__/_helpers.js
@@ -99,7 +99,7 @@ const scrollResultSet = (self, callback, loadedHits, response) => {
         const hits = body.hits.hits
 
         if (self.lastScrollId) {
-          self.parent.emit('debug', `lastScrollId: ${self.lastScrollId}`)
+          console.log(`Scroll ID: ${self.lastScrollId}`)
         }
 
         if (body.terminated_early && body._shards && body._shards.failed > 0) {


### PR DESCRIPTION
Having Scroll ID printed all the time is helpfull, had couple of cases that I needed to retry many times becuase I forgot to enable debug