### PR TITLE
Update Regex in multielasticdump

### DIFF
--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -397,7 +397,7 @@ if (options.direction === 'load') {
     }
     // args.log('info', data);
     matchedIndexes = data.map(value => value
-      .replace(new RegExp(`.(${supportedTypes.join('|')}).${fileExt}`), '')
+      .replace(new RegExp(`\\.(${supportedTypes.join('|')})\\.${fileExt}`), '')
       .replace(`.${fileExt}`, '')
       .replace('/', ''))
       .filter(item => matchRegExp.test(item))


### PR DESCRIPTION
Hi,

I've been facing an issue with multielasticdump during restore.

the dump would complete without issue but the restore would fail complaining about not able to find a particular json final in the "dump" directory.

some context for below. In my company indexes are named `<tenant>.<purpose>index`
(ending with index is the important bit)

I took a quick glance at the code and noticed that the regex to convert the filenames to index names did not escape the period, making it a wildcard. This resulted in indexes that ended with a "supported type" in its name to get screwed up.

eg:

original filename: `customerx.userindex.template.json`
after regex: `customerx.use`
expected: `customerx.userindex`

This tiny change should fix my issue (and potential issues others might face)

Please review the change and let me know if I've missed something.
