### PR TITLE
Issues-1077 / Issue-1083 - Prefetch reads in-order / background flush writes in-order using `p-map-iterable`

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,6 +1,5 @@
 const { EventEmitter } = require('events')
-const { default: PQueue } = require('p-queue')
-const { IterableMapper } = require('@shutterstock/p-map-iterable')
+const { IterableMapper, IterableQueueMapperSimple } = require('@shutterstock/p-map-iterable')
 const delay = require('delay')
 const vm = require('vm')
 const path = require('path')
@@ -82,13 +81,7 @@ class TransportProcessor extends EventEmitter {
   }
 
   async _loop (limit, offset, totalWrites) {
-    const queue = new PQueue({
-      concurrency: this.options.concurrency || Infinity,
-      interval: this.options.concurrencyInterval || 0,
-      intervalCap: this.options.intervalCap || Infinity,
-      carryoverConcurrencyCount: this.options.carryoverConcurrencyCount || false
-    })
-    return this.__looper(limit, offset, totalWrites, queue)
+    return this.__looper(limit, offset, totalWrites)
       .then(totalWrites => {
         this.log(`Total Writes: ${totalWrites}`)
         this.log('dump complete')
@@ -102,7 +95,7 @@ class TransportProcessor extends EventEmitter {
       })
   }
 
-  async __looper (limit, offset, totalWrites, queue) {
+  async __looper (limit, offset, totalWrites) {
     const ignoreErrors = this.options['ignore-errors'] === true
     const prefetcher = new IterableMapper(
       this.offsetGenerator(limit, offset),
@@ -117,41 +110,59 @@ class TransportProcessor extends EventEmitter {
         maxUnread: Math.max(5, 2 * (Math.min(this.options.concurrency, 20) || 1))
       }
     )
+    // Async background flusher for writes
+    // Default `concurrency: 1` will preserve the order of the writes
+    // and just allow the next read / `applyModifiers` to begin
+    // while the last write completes
+    const flusher = new IterableQueueMapperSimple(async ({ data, offset }) => {
+      // Write the data to the destination
+      try {
+        const writes = await this.set(data, limit, offset)
+        totalWrites += writes
+        if (data.length > 0) {
+          this.log(`sent ${data.length} objects, ${offset} offset, to destination ${this.outputType}, wrote ${writes}`)
+        }
+      } catch (err) {
+        if (!ignoreErrors) {
+          // This will add the error to the `flusher.errors` array
+          // We are just going to check that and throw the first one
+          throw err
+        }
+
+        // Only emit the error if we didn't throw out
+        // If we throw out, _loop will emit
+        this.emit('error', err)
+      }
+    },
+    {
+      concurrency: this.options.concurrency || 1
+    })
 
     // Iterate over the prefetched row blocks, in order
     // Typically there will always be a prefetched read so we will not wait here
     for await (const value of prefetcher) {
+      // Bail out if there is a write error and we are not ignoring them
+      if (!ignoreErrors && flusher.errors && flusher.errors.length > 0) {
+        throw flusher.errors[0]
+      }
+
       const { data, offset } = value
       this.log(`got ${data.length} objects from source ${this.inputType} (offset: ${offset})`)
 
-      // We always setup the write because data [] is used to close the stream
-      const overlappedIoPromise = this.set(data, limit, offset).catch(err => {
-        if (ignoreErrors) {
-          // We only emit if continuing to run after errors
-          // If stopping after errors then the catch in _loop will emit
-          this.emit('error', err)
-          return Promise.resolve(0)
-        }
-
-        return Promise.reject(err)
-      })
-
       if (data.length === 0) {
-        await queue.onIdle()
-        // Trigger the close of the destination stream
-        await overlappedIoPromise
+        // Write the empty data to trigger file close
+        await flusher.enqueue({ data, offset })
+
+        // Finish all queued writes
+        await flusher.onIdle()
+
         // Break out of the `while (true)` loop and end the process
         return totalWrites
       } else {
         this.applyModifiers(data)
 
-        // NOTE: this doesn't really do anything as `queue.add()` returns only when the passed promise resolves,
-        // which is evidenced by the fact that `queue.add()` returns the resolved value of the passed promise
-        const writes = await queue.add(() => overlappedIoPromise)
-        totalWrites += writes
-        this.log(`sent ${data.length} objects to destination ${this.outputType}, wrote ${writes}`)
-
-        offset += data.length
+        // Wait if flusher has no slots, otherwise no delay
+        await flusher.enqueue({ data, offset })
 
         await delay(this.options.throttleInterval || 0)
       }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -150,15 +150,19 @@ class TransportProcessor extends EventEmitter {
       this.log(`got ${data.length} objects from source ${this.inputType} (offset: ${offset})`)
 
       if (data.length === 0) {
-        // Write the empty data to trigger file close
-        await flusher.enqueue({ data, offset })
-
         // Finish all queued writes
         await flusher.onIdle()
+
+        // Write the empty data to trigger file close
+        // We only do this after the idle event so we do
+        // not write close the destination before writes finish
+        // (e.g. with `concurrency` > 1)
+        await this.set(data, limit, offset)
 
         // Break out of the `while (true)` loop and end the process
         return totalWrites
       } else {
+        // Only apply modifiers when we have non-zero length data
         this.applyModifiers(data)
 
         // Wait if flusher has no slots, otherwise no delay

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,5 +1,6 @@
 const { EventEmitter } = require('events')
 const { default: PQueue } = require('p-queue')
+const { IterableMapper } = require('@shutterstock/p-map-iterable')
 const delay = require('delay')
 const vm = require('vm')
 const path = require('path')
@@ -71,6 +72,15 @@ class TransportProcessor extends EventEmitter {
       }, {})
   }
 
+  * offsetGenerator (limit, offset) {
+    // This does not need to ever stop
+    // We stop iterating this generator in __looper when we get an empty result
+    while (true) {
+      yield offset
+      offset += limit
+    }
+  }
+
   async _loop (limit, offset, totalWrites) {
     const queue = new PQueue({
       concurrency: this.options.concurrency || Infinity,
@@ -94,10 +104,24 @@ class TransportProcessor extends EventEmitter {
 
   async __looper (limit, offset, totalWrites, queue) {
     const ignoreErrors = this.options['ignore-errors'] === true
+    const prefetcher = new IterableMapper(
+      this.offsetGenerator(limit, offset),
+      async (offset) => {
+        const data = await this.get(limit, offset)
+        return { data, offset }
+      },
+      {
+        // Reading from ES scrolls or files both require reading in-order
+        // so we set `concurrency` to 1 and do not allow it to be changed
+        concurrency: 1,
+        maxUnread: Math.max(5, 2 * (Math.min(this.options.concurrency, 20) || 1))
+      }
+    )
 
-    while (true) {
-      const data = await this.get(limit, offset)
-
+    // Iterate over the prefetched row blocks, in order
+    // Typically there will always be a prefetched read so we will not wait here
+    for await (const value of prefetcher) {
+      const { data, offset } = value
       this.log(`got ${data.length} objects from source ${this.inputType} (offset: ${offset})`)
 
       // We always setup the write because data [] is used to close the stream

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "lodash": "^4.17.21",
     "lossless-json": "^1.0.5",
     "minimist": "^1.2.8",
-    "p-queue": "^6.6.2",
     "request": "npm:@cypress/request@>=3.0.1 <3.0.6",
     "requestretry": "^7.1.0",
     "s3-stream-upload": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
+    "@shutterstock/p-map-iterable": "^1.1.2",
     "async": "^2.6.4",
     "aws-sdk": "2.1472.0",
     "aws4": "^1.12.0",

--- a/test/processor.tests.js
+++ b/test/processor.tests.js
@@ -327,9 +327,17 @@ describe('TransportProcessor', () => {
         emitErrorCount++
       })
 
-      const totalWrites = await transport._loop(1, 0, 0)
+      let loopError = false
+      let totalWrites = 0
+      try {
+        totalWrites = await transport._loop(1, 0, 0)
+      } catch {
+        // Should not throw
+        loopError = true
+      }
 
       // Should complete despite error
+      loopError.should.equal(false)
       emitErrorCount.should.equal(1)
       totalWrites.should.equal(1)
       transport.outputData.should.have.length(1)

--- a/test/processor.tests.js
+++ b/test/processor.tests.js
@@ -196,7 +196,7 @@ describe('TransportProcessor', () => {
 
   describe('offsetGenerator', () => {
     // This will be used in p-map-iterable version
-    it.skip('should generate increasing offsets', async () => {
+    it('should generate increasing offsets', async () => {
       const generator = processor.offsetGenerator(10, 0)
       const results = []
       for await (const offset of generator) {


### PR DESCRIPTION
## Release Suggestions
- [x] Merge PRs for Promises leak fix
- [x] Merge tests and fixes for stopping on errors #1089
- [x] Release contents of `master` at this point as this should have no dependency or speed changes
- [x] Wait for other PRs to merge:
   - [x] #1092 
   - [x] #1094 
   - [x] #1095 
   - [x] #1090 
- [x] Rebase this PR and resolve merge conflicts
- [x] Confirm tests are passing 
- [ ] Bump major version before releasing this PR - This PR will remove the 5 batches per 5 seconds default throttle and use only backpressure and `throttleInterval` to slow down the overall rate
- [ ] Merge and release this PR

## Changes
- Performance Summary
   - 3.5x to 6.4x faster with default settings for both, node 20, 7-27 ms RTT from ES
   - 2.5x to 3x faster with optimal settings for both, node 20, 7-27 ms RTT from ES
   - 10x to 20x faster with concurrency 10 vs defaults for baseline, node 20, 7-27 ms RTT from ES
- Compatible with Node v10
- Usage with Node v20 is highly recommended as it allows 2-3x higher performance vs v18
- Keep reads and writes in-order by default
- Does not allow changing reads to out-of-order (as ES scrolls and files are both incompatible with that)
- `concurrency` option (if value > 1) allows out of order writes with up to `concurrency` in-progress writes before applying backpressure - can be used with ES destination but should not be used with files
- Removes 5 batches per 5 seconds behavior that was being imposed by default settings of `queue`
   - `carryoverConcurrencyCount` - No longer does anything
   - `intervalCap` - No longer does anything
   - `concurrencyInterval` - No longer does anything
- Throttling is entirely controlled by:
   - `throttleInterval`
   - Speed of reads and RTT
   - Speed of writes and RTT
   - Backpressure of writes (typically the longest operation)
- Fixes #1077 
- Fixes #1083

## Performance

### Table of Results

Note: 6.117.0 was not re-run with `node 20` because the limiting factor was the default `--intervalCap=5` which held the throughput rate to 1 batch every second.

| Configuration | Node Version | Records Written | Duration (s) | Avg RTT (ms) | Records / Batch | Batches / Second |
|--------------|--------------|----------------:|-------------:|-------------:|--------------:|---------------:|
| PR (concurrency=10, limit=1000, esCompress=true) | 20.13.1 | 66,000 | 30 | 7 | 1,000 | 2.2 |
| PR (concurrency=10) | 20.13.1 | 61,400 | 30 | 7 | 100 | 20.5 |
| PR (concurrency=10, limit=1000, esCompress=true) | 20.13.1 | 56,000 | 30 | 26.7 | 1,000 | 1.9 |
| PR (concurrency=10) | 20.13.1 | 30,500 | 30 | 26.7 | 100 | 10.2 |
| PR (concurrency=10) | 18.16.1 | 13,000 | 30 | 26.7 | 100 | 4.3 |
| PR (concurrency=1) | 20.13.1 | 19,200 | 30 | 7 | 100 | 6.4 |
| PR (concurrency=1) | 20.13.1 | 10,500 | 30 | 26.7 | 100 | 3.5 |
| PR (concurrency=1) | 18.16.1 | 6,300 | 30 | 26.7 | 100 | 2.1 |
| Baseline (intervalCap=100) | 20.13.1 | 16,200 | 30 | 7 | 100 | 5.4 |
| Baseline (intervalCap=100) | 20.13.1 | 8,100 | 30 | 26.7 | 100 | 2.7 |
| Baseline (intervalCap=100) | 18.16.1 | 4,200 | 30 | 26.7 | 100 | 1.4 |
| Baseline (intervalCap=5, limit=1000, esCompress=true) | 20.13.1 | 26,000 | 30 | 7 | 1,000 | 0.87 |
| Baseline (intervalCap=5, limit=1000, esCompress=true) | 20.13.1 | 22,000 | 30 | 26.7 | 1,000 | 0.7 |
| Baseline (intervalCap=5) | 18.16.1 | 3,200 | 30 | 26.7 | 100 | 1.06 |

<details>
<summary>Details - Command Lines - Log Outputs</summary>

### This PR with `--concurrency=10` for Writes - `node 20` - `1k Limit` - `esCompress` - `Short RTT`

- Node: 20.13.1
- Records Written: 66,000
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 7 ms
- Records per Batch: 100
- Batches / Second = 66,000 / 1,000 / 30 = 2.2

#### Command Line

```sh
npx elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}" --concurrency=10 --limit=1000 --esCompress=true
```

```log
Fri, 14 Feb 2025 21:08:08 GMT | starting dump
Fri, 14 Feb 2025 21:08:09 GMT | got 1000 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 21:08:09 GMT | got 1000 objects from source elasticsearch (offset: 1000)
Fri, 14 Feb 2025 21:08:09 GMT | sent 1000 objects, 0 offset, to destination elasticsearch, wrote 1000
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 21:08:37 GMT | got 1000 objects from source elasticsearch (offset: 69000)
Fri, 14 Feb 2025 21:08:37 GMT | got 1000 objects from source elasticsearch (offset: 70000)
Fri, 14 Feb 2025 21:08:38 GMT | sent 1000 objects, 65000 offset, to destination elasticsearch, wrote 1000
Fri, 14 Feb 2025 21:08:38 GMT | sent 1000 objects, 66000 offset, to destination elasticsearch, wrote 1000
Fri, 14 Feb 2025 21:08:38 GMT | sent 1000 objects, 67000 offset, to destination elasticsearch, wrote 1000
Fri, 14 Feb 2025 21:08:38 GMT | sent 1000 objects, 68000 offset, to destination elasticsearch, wrote 1000
Fri, 14 Feb 2025 21:08:38 GMT | sent 1000 objects, 69000 offset, to destination elasticsearch, wrote 1000
```

### This PR with `--concurrency=10` for Writes - `node 20` - `1k Limit` - `esCompress`

- Node: 20.13.1
- Records Written: 56,000
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 26.7 ms
- Records per Batch: 100
- Batches / Second = 56,000 / 1,000 / 30 = 1.87

#### Command Line

```sh
npx elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}" --concurrency=10 --limit=1000 --esCompress=true
```

```log
Fri, 14 Feb 2025 20:54:44 GMT | starting dump
Fri, 14 Feb 2025 20:54:45 GMT | got 1000 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 20:54:45 GMT | got 1000 objects from source elasticsearch (offset: 1000)
Fri, 14 Feb 2025 20:54:45 GMT | sent 1000 objects, 0 offset, to destination elasticsearch, wrote 1000
Fri, 14 Feb 2025 20:54:46 GMT | sent 1000 objects, 1000 offset, to destination elasticsearch, wrote 1000
Fri, 14 Feb 2025 20:54:46 GMT | got 1000 objects from source elasticsearch (offset: 2000)
Fri, 14 Feb 2025 20:54:47 GMT | got 1000 objects from source elasticsearch (offset: 3000)
Fri, 14 Feb 2025 20:54:47 GMT | sent 1000 objects, 2000 offset, to destination elasticsearch, wrote 1000
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 20:55:14 GMT | got 1000 objects from source elasticsearch (offset: 55000)
Fri, 14 Feb 2025 20:55:14 GMT | sent 1000 objects, 54000 offset, to destination elasticsearch, wrote 1000
Fri, 14 Feb 2025 20:55:14 GMT | got 1000 objects from source elasticsearch (offset: 56000)
Fri, 14 Feb 2025 20:55:15 GMT | got 1000 objects from source elasticsearch (offset: 57000)
Fri, 14 Feb 2025 20:55:15 GMT | sent 1000 objects, 55000 offset, to destination elasticsearch, wrote 1000
```

### This PR with `--concurrency=10` for Writes - `node 20` - `short RTT`

- Node: 20.13.1
- Records Written: 61,400
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 7 ms
- Records per Batch: 100
- Batches / Second = 61,400 / 100 / 30 = 20.5

#### Command Line

```sh
npx elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}" --concurrency=10
```

```log
Fri, 14 Feb 2025 19:01:21 GMT | starting dump
Fri, 14 Feb 2025 19:01:21 GMT | got 100 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 19:01:21 GMT | got 100 objects from source elasticsearch (offset: 100)
Fri, 14 Feb 2025 19:01:21 GMT | got 100 objects from source elasticsearch (offset: 200)
...
Fri, 14 Feb 2025 19:01:21 GMT | got 100 objects from source elasticsearch (offset: 1800)
Fri, 14 Feb 2025 19:01:21 GMT | sent 100 objects, 800 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:01:21 GMT | got 100 objects from source elasticsearch (offset: 1900)
Fri, 14 Feb 2025 19:01:22 GMT | sent 100 objects, 900 offset, to destination elasticsearch, wrote 100
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 19:01:50 GMT | got 100 objects from source elasticsearch (offset: 61900)
Fri, 14 Feb 2025 19:01:50 GMT | sent 100 objects, 60900 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:01:50 GMT | got 100 objects from source elasticsearch (offset: 62000)
Fri, 14 Feb 2025 19:01:50 GMT | sent 100 objects, 61100 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:01:50 GMT | got 100 objects from source elasticsearch (offset: 62100)
Fri, 14 Feb 2025 19:01:50 GMT | sent 100 objects, 61000 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:01:50 GMT | got 100 objects from source elasticsearch (offset: 62200)
Fri, 14 Feb 2025 19:01:50 GMT | sent 100 objects, 61200 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:01:50 GMT | got 100 objects from source elasticsearch (offset: 62300)
Fri, 14 Feb 2025 19:01:51 GMT | sent 100 objects, 61300 offset, to destination elasticsearch, wrote 100
```

### This PR with `--concurrency=10` for Writes - `node 20`

- Node: 20.13.1
- Records Written: 30,500
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 26.7 ms
- Records per Batch: 100
- Batches / Second = 30,500 / 100 / 30 = 10.2

#### Command Line

```sh
npx elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}" --concurrency=10
```

```log
Fri, 14 Feb 2025 18:29:43 GMT | starting dump
Fri, 14 Feb 2025 18:29:43 GMT | got 100 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 18:29:44 GMT | got 100 objects from source elasticsearch (offset: 100)
Fri, 14 Feb 2025 18:29:44 GMT | got 100 objects from source elasticsearch (offset: 200)
Fri, 14 Feb 2025 18:29:44 GMT | got 100 objects from source elasticsearch (offset: 300)
Fri, 14 Feb 2025 18:29:44 GMT | got 100 objects from source elasticsearch (offset: 400)
Fri, 14 Feb 2025 18:29:44 GMT | got 100 objects from source elasticsearch (offset: 500)
Fri, 14 Feb 2025 18:29:44 GMT | got 100 objects from source elasticsearch (offset: 600)
Fri, 14 Feb 2025 18:29:44 GMT | got 100 objects from source elasticsearch (offset: 700)
Fri, 14 Feb 2025 18:29:44 GMT | sent 100 objects, 500 offset, to destination elasticsearch, wrote 100
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 18:30:13 GMT | sent 100 objects, 30200 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:30:13 GMT | got 100 objects from source elasticsearch (offset: 30500)
Fri, 14 Feb 2025 18:30:13 GMT | got 100 objects from source elasticsearch (offset: 30600)
Fri, 14 Feb 2025 18:30:13 GMT | sent 100 objects, 30300 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:30:14 GMT | got 100 objects from source elasticsearch (offset: 30700)
Fri, 14 Feb 2025 18:30:14 GMT | sent 100 objects, 30400 offset, to destination elasticsearch, wrote 100
```

### This PR with `--concurrency=10` for Writes - `node 18`

- Node: 18.16.1
- Records Written: 13,000
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 26.7 ms
- Records per Batch: 100
- Batches / Second = 13,000 / 100 / 30 = 4.3

#### Command Line

```sh
npx elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}" --concurrency=10
```

```log
Fri, 14 Feb 2025 18:08:06 GMT | starting dump
Fri, 14 Feb 2025 18:08:06 GMT | got 100 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 18:08:07 GMT | got 100 objects from source elasticsearch (offset: 100)
Fri, 14 Feb 2025 18:08:07 GMT | got 100 objects from source elasticsearch (offset: 200)
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 18:08:36 GMT | sent 100 objects, 12700 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:08:36 GMT | got 100 objects from source elasticsearch (offset: 13000)
Fri, 14 Feb 2025 18:08:36 GMT | sent 100 objects, 12800 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:08:37 GMT | sent 100 objects, 12900 offset, to destination elasticsearch, wrote 100
```

### This PR with Default `--concurrency=1` for Writes - `node 20` - `Short RTT`

- Node: 20.13.1
- Records Written: 19,200
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 7 ms
- Records per Batch: 100
- Batches / Second = 19,200 / 100 / 30 = 6.4

#### Command Line

```sh
npx elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}"
```

#### Start of Dump

```log
Fri, 14 Feb 2025 19:05:11 GMT | starting dump
Fri, 14 Feb 2025 19:05:11 GMT | got 100 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 19:05:11 GMT | got 100 objects from source elasticsearch (offset: 100)
Fri, 14 Feb 2025 19:05:11 GMT | sent 100 objects, 0 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:05:11 GMT | got 100 objects from source elasticsearch (offset: 200)
Fri, 14 Feb 2025 19:05:11 GMT | sent 100 objects, 100 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:05:11 GMT | got 100 objects from source elasticsearch (offset: 300)
Fri, 14 Feb 2025 19:05:11 GMT | sent 100 objects, 200 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:05:11 GMT | got 100 objects from source elasticsearch (offset: 400)
Fri, 14 Feb 2025 19:05:12 GMT | sent 100 objects, 300 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:05:12 GMT | got 100 objects from source elasticsearch (offset: 500)
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 19:05:40 GMT | sent 100 objects, 18800 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:05:40 GMT | got 100 objects from source elasticsearch (offset: 19000)
Fri, 14 Feb 2025 19:05:40 GMT | sent 100 objects, 18900 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:05:40 GMT | got 100 objects from source elasticsearch (offset: 19100)
Fri, 14 Feb 2025 19:05:40 GMT | sent 100 objects, 19000 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:05:40 GMT | got 100 objects from source elasticsearch (offset: 19200)
Fri, 14 Feb 2025 19:05:41 GMT | sent 100 objects, 19100 offset, to destination elasticsearch, wrote 100
```

### This PR with Default `--concurrency=1` for Writes - `node 20`

- Node: 20.13.1
- Records Written: 10,500
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 26.7 ms
- Records per Batch: 100
- Batches / Second = 10,500 / 100 / 30 = 3.5

#### Command Line

```sh
npx elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}"
```

#### Start of Dump

```log
Fri, 14 Feb 2025 18:32:44 GMT | starting dump
Fri, 14 Feb 2025 18:32:44 GMT | got 100 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 18:32:44 GMT | got 100 objects from source elasticsearch (offset: 100)
Fri, 14 Feb 2025 18:32:45 GMT | sent 100 objects, 0 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:32:45 GMT | got 100 objects from source elasticsearch (offset: 200)
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 18:33:14 GMT | sent 100 objects, 10200 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:33:14 GMT | got 100 objects from source elasticsearch (offset: 10400)
Fri, 14 Feb 2025 18:33:14 GMT | sent 100 objects, 10300 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:33:14 GMT | got 100 objects from source elasticsearch (offset: 10500)
Fri, 14 Feb 2025 18:33:15 GMT | sent 100 objects, 10400 offset, to destination elasticsearch, wrote 100
```

### This PR with Default `--concurrency=1` for Writes - `node 18`

- Node: 18.16.1
- Records Written: 6,300
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 26.7 ms
- Records per Batch: 100
- Batches / Second = 6,300 / 100 / 30 = 2.1

#### Command Line

```sh
npx elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}"
```

#### Start of Dump

```log
Fri, 14 Feb 2025 17:56:24 GMT | starting dump
Fri, 14 Feb 2025 17:56:25 GMT | got 100 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 17:56:25 GMT | got 100 objects from source elasticsearch (offset: 100)
Fri, 14 Feb 2025 17:56:26 GMT | sent 100 objects, 0 offset, to destination elasticsearch, wrote 100
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 17:56:54 GMT | got 100 objects from source elasticsearch (offset: 6200)
Fri, 14 Feb 2025 17:56:54 GMT | sent 100 objects, 6100 offset, to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 17:56:54 GMT | got 100 objects from source elasticsearch (offset: 6300)
Fri, 14 Feb 2025 17:56:55 GMT | sent 100 objects, 6200 offset, to destination elasticsearch, wrote 100
```

### Baseline of `6.117.0` with `--intervalCap=100` - `node 20` - `Short RTT`

- Node: 20.13.1
- Records Written: 16,200
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 7 ms
- Records per Batch: 100
- Batches / Second = 16,200 / 100 / 30 = 5.4

#### Command Line

```sh
elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}" --intervalCap=100 
```

#### Start of Dump

```log
Fri, 14 Feb 2025 19:33:32 GMT | starting dump
Fri, 14 Feb 2025 19:33:32 GMT | got 100 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 19:33:32 GMT | sent 100 objects to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:33:32 GMT | got 100 objects from source elasticsearch (offset: 100)
Fri, 14 Feb 2025 19:33:32 GMT | sent 100 objects to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:33:32 GMT | got 100 objects from source elasticsearch (offset: 200)
Fri, 14 Feb 2025 19:33:32 GMT | sent 100 objects to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:33:33 GMT | got 100 objects from source elasticsearch (offset: 300)
Fri, 14 Feb 2025 19:33:33 GMT | sent 100 objects to destination elasticsearch, wrote 100
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 19:34:01 GMT | sent 100 objects to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:34:01 GMT | got 100 objects from source elasticsearch (offset: 15900)
Fri, 14 Feb 2025 19:34:01 GMT | sent 100 objects to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:34:01 GMT | got 100 objects from source elasticsearch (offset: 16000)
Fri, 14 Feb 2025 19:34:01 GMT | sent 100 objects to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 19:34:01 GMT | got 100 objects from source elasticsearch (offset: 16100)
Fri, 14 Feb 2025 19:34:02 GMT | sent 100 objects to destination elasticsearch, wrote 100
```

### Baseline of `6.117.0` with `--intervalCap=100` - `node 20`

- Node: 20.13.1
- Records Written: 8,100
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 26.7 ms
- Records per Batch: 100
- Batches / Second = 8,100 / 100 / 30 = 2.7

#### Command Line

```sh
elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}" --intervalCap=100 
```

#### Start of Dump

```log
Fri, 14 Feb 2025 18:25:00 GMT | starting dump
Fri, 14 Feb 2025 18:25:00 GMT | got 100 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 18:25:01 GMT | sent 100 objects to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:25:01 GMT | got 100 objects from source elasticsearch (offset: 100)
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 18:25:30 GMT | got 100 objects from source elasticsearch (offset: 7900)
Fri, 14 Feb 2025 18:25:30 GMT | sent 100 objects to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:25:30 GMT | got 100 objects from source elasticsearch (offset: 8000)
Fri, 14 Feb 2025 18:25:31 GMT | sent 100 objects to destination elasticsearch, wrote 100
```

### Baseline of `6.117.0` with `--intervalCap=100` - `node 18`

- Node: 18.16.1
- Records Written: 4,200
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 26.7 ms
- Records per Batch: 100
- Batches / Second = 4,200 / 100 / 30 = 1.4

#### Command Line

```sh
elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}" --intervalCap=100 
```

#### Start of Dump

```log
Fri, 14 Feb 2025 18:15:29 GMT | starting dump
Fri, 14 Feb 2025 18:15:29 GMT | got 100 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 18:15:30 GMT | sent 100 objects to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:15:30 GMT | got 100 objects from source elasticsearch (offset: 100)
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 18:15:58 GMT | sent 100 objects to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:15:58 GMT | got 100 objects from source elasticsearch (offset: 4100)
Fri, 14 Feb 2025 18:15:59 GMT | sent 100 objects to destination elasticsearch, wrote 100
```

### Baseline of `6.117.0` with Default `--intervalCap=5` - `node 20` - `esCompress` - `Short RTT`

- Node: 20.13.1
- Records Written: 26,000
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 7 ms
- Records per Batch: 1,000
- Batches / Second = 26,000 / 1,000 / 30 = 0.87

#### Command Line

```sh
elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}" --limit 1000 --esCompress=1000
```

#### Start of Dump

```log
Fri, 14 Feb 2025 21:13:28 GMT | starting dump
Fri, 14 Feb 2025 21:13:28 GMT | got 1000 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 21:13:29 GMT | sent 1000 objects to destination elasticsearch, wrote 1000
Fri, 14 Feb 2025 21:13:29 GMT | got 1000 objects from source elasticsearch (offset: 1000)
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 21:13:56 GMT | got 1000 objects from source elasticsearch (offset: 25000)
Fri, 14 Feb 2025 21:13:57 GMT | sent 1000 objects to destination elasticsearch, wrote 1000
Fri, 14 Feb 2025 21:13:58 GMT | got 1000 objects from source elasticsearch (offset: 26000)
Fri, 14 Feb 2025 21:13:58 GMT | sent 1000 objects to destination elasticsearch, wrote 1000
```

### Baseline of `6.117.0` with Default `--intervalCap=5` - `node 20` - `esCompress`

- Node: 18.16.1
- Records Written: 22,000
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 26.7 ms
- Records per Batch: 1,000
- Batches / Second = 22,000 / 1,000 / 30 = 0.73

#### Command Line

```sh
elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}" --limit 1000 --esCompress=1000
```

#### Start of Dump

```log
Fri, 14 Feb 2025 21:04:21 GMT | starting dump
Fri, 14 Feb 2025 21:04:22 GMT | got 1000 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 21:04:23 GMT | sent 1000 objects to destination elasticsearch, wrote 1000
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 21:04:50 GMT | got 1000 objects from source elasticsearch (offset: 21000)
Fri, 14 Feb 2025 21:04:51 GMT | sent 1000 objects to destination elasticsearch, wrote 1000
```

### Baseline of `6.117.0` with Default `--intervalCap=5` - `node 18`

- Node: 18.16.1
- Records Written: 3,200
- Duration: 30 seconds
- Average RTT (established socket) to Source and Target: 26.7 ms
- Records per Batch: 100
- Batches / Second = 3,200 / 100 / 30 = 1.06

#### Command Line

```sh
elasticdump --input=https://source_es/some_index --output=https://target_es/some_index --type=data --input-params="{\"preference\":\"_shards:0\"}"
```

#### Start of Dump

```log
Fri, 14 Feb 2025 18:12:18 GMT | starting dump
Fri, 14 Feb 2025 18:12:18 GMT | got 100 objects from source elasticsearch (offset: 0)
Fri, 14 Feb 2025 18:12:19 GMT | sent 100 objects to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:12:19 GMT | got 100 objects from source elasticsearch (offset: 100)
```

#### End of 30 Seconds of Dump

```log
Fri, 14 Feb 2025 18:12:47 GMT | sent 100 objects to destination elasticsearch, wrote 100
Fri, 14 Feb 2025 18:12:48 GMT | got 100 objects from source elasticsearch (offset: 3100)
Fri, 14 Feb 2025 18:12:49 GMT | sent 100 objects to destination elasticsearch, wrote 100
```

</details>

## Confirmation of Promises Leak Fix

<img width="1169" alt="image" src="https://github.com/user-attachments/assets/5b6797e6-1364-4e9a-9573-e5e7c28b88f3" />
