### PR TITLE
Issue-1083 - Fix promise leak in __looper

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -119,7 +119,7 @@ class TransportProcessor extends EventEmitter {
         // Should always emit write errors just like we do for read errors
         this.emit('error', err)
 
-        if (!ignoreErrors) {
+        if (ignoreErrors) {
           return Promise.resolve(0)
         }
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -95,52 +95,54 @@ class TransportProcessor extends EventEmitter {
   async __looper (limit, offset, totalWrites, queue) {
     const ignoreErrors = this.options['ignore-errors'] === true
 
-    return new Promise((resolve, reject) => {
-      this.input.get(limit, offset, (err, data) => {
-        if (err) {
-          this.emit('error', err)
-          if (!ignoreErrors) {
-            return reject(err)
-          }
-        }
-
-        this.log(`got ${data.length} objects from source ${this.inputType} (offset: ${offset})`)
-        this.applyModifiers(data)
-
-        const overlappedIoPromise = this.set(data, limit, offset)
-          .then(writes => {
-            totalWrites += writes
-            if (data.length > 0) {
-              this.log(`sent ${data.length} objects to destination ${this.outputType}, wrote ${writes}`)
-            }
-          })
-          .catch(err => {
-            if (ignoreErrors) {
-              return Promise.resolve()
-            }
-
+    while (true) {
+      const readPromise = new Promise((resolve, reject) => {
+        this.input.get(limit, offset, (err, data) => {
+          if (err) {
             this.emit('error', err)
-            return Promise.reject(err)
-          })
+            if (!ignoreErrors) {
+              // This will cause `await readPromise` to throw out of the loop and
+              // out of the `__looper` function.
+              return reject(err)
+            }
+          }
+          resolve(data || [])
+        })
+      });
+      
+      const data = await readPromise
 
-        if (data.length === 0) {
-          return queue.onIdle()
-            .then(() => resolve(totalWrites))
-            .catch(reject)
-        } else {
-          return queue.add(() => overlappedIoPromise)
-            .then(() => {
-              offset += data.length
-              return delay(this.options.throttleInterval || 0)
-                .then(() => {
-                  return this.__looper(limit, offset, totalWrites, queue)
-                    .then(resolve)
-                })
-            })
-            .catch(reject)
+      this.log(`got ${data.length} objects from source ${this.inputType} (offset: ${offset})`)
+      this.applyModifiers(data)
+
+      const overlappedIoPromise = this.set(data, limit, offset).catch(err => {
+        // Should always emit write errors just like we do for read errors
+        this.emit('error', err)
+
+        if (!ignoreErrors) {
+          return Promise.resolve(0)
         }
+
+        return Promise.reject(err)
       })
-    })
+      // NOTE: this doesn't really do anything as `queue.add()` returns only when the passed promise resolves,
+      // which is evidenced by the fact that `queue.add()` returns the resolved value of the passed promise
+      const writes = await queue.add(() => overlappedIoPromise)
+      totalWrites += writes
+      if (data.length > 0) {
+        this.log(`sent ${data.length} objects to destination ${this.outputType}, wrote ${writes}`)
+      }
+
+      if (data.length === 0) {
+        await queue.onIdle()
+        // Break out of the `while (true)` loop and end the process
+        return totalWrites
+      } else {
+        offset += data.length
+
+        await delay(this.options.throttleInterval || 0)
+      }
+    }
   }
 }
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -108,8 +108,8 @@ class TransportProcessor extends EventEmitter {
           }
           resolve(data || [])
         })
-      });
-      
+      })
+
       const data = await readPromise
 
       this.log(`got ${data.length} objects from source ${this.inputType} (offset: ${offset})`)


### PR DESCRIPTION
## Changes
- Tested with Node v10
- Merge after #1086
- REVIEW: will `emit` write errors just like read errors are always emitted - this was a mismatch between handling of `ignoreErrors` on reads and writes - if not desired this can be changed
  - There are bigger things to review with read/write error handling though as it appears that any read errors will cause an end to the iteration and that might not be avoidable
- Flatten the `__looper` into an iterative function with async/await that removes the recursive call to `__looper`
- Confirmed that the Promise / closure leak is fixed
- Confirmed that the default 5 batches / 5 seconds behavior of the `queue` is preserved
- Fixes #1083

## Confirmation

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/566fe203-0236-4c1e-98dc-1ff876302dfa" />
