### PR TITLE
Fix 3 tests after promise leak fix

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -136,9 +136,7 @@ class TransportProcessor extends EventEmitter {
         // which is evidenced by the fact that `queue.add()` returns the resolved value of the passed promise
         const writes = await queue.add(() => overlappedIoPromise)
         totalWrites += writes
-        if (data.length > 0) {
-          this.log(`sent ${data.length} objects to destination ${this.outputType}, wrote ${writes}`)
-        }
+        this.log(`sent ${data.length} objects to destination ${this.outputType}, wrote ${writes}`)
 
         offset += data.length
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -113,31 +113,33 @@ class TransportProcessor extends EventEmitter {
       const data = await readPromise
 
       this.log(`got ${data.length} objects from source ${this.inputType} (offset: ${offset})`)
-      this.applyModifiers(data)
-
-      const overlappedIoPromise = this.set(data, limit, offset).catch(err => {
-        // Should always emit write errors just like we do for read errors
-        this.emit('error', err)
-
-        if (ignoreErrors) {
-          return Promise.resolve(0)
-        }
-
-        return Promise.reject(err)
-      })
-      // NOTE: this doesn't really do anything as `queue.add()` returns only when the passed promise resolves,
-      // which is evidenced by the fact that `queue.add()` returns the resolved value of the passed promise
-      const writes = await queue.add(() => overlappedIoPromise)
-      totalWrites += writes
-      if (data.length > 0) {
-        this.log(`sent ${data.length} objects to destination ${this.outputType}, wrote ${writes}`)
-      }
 
       if (data.length === 0) {
         await queue.onIdle()
         // Break out of the `while (true)` loop and end the process
         return totalWrites
       } else {
+        this.applyModifiers(data)
+
+        const overlappedIoPromise = this.set(data, limit, offset).catch(err => {
+          // Should always emit write errors just like we do for read errors
+          this.emit('error', err)
+  
+          if (ignoreErrors) {
+            return Promise.resolve(0)
+          }
+  
+          return Promise.reject(err)
+        })
+
+        // NOTE: this doesn't really do anything as `queue.add()` returns only when the passed promise resolves,
+        // which is evidenced by the fact that `queue.add()` returns the resolved value of the passed promise
+        const writes = await queue.add(() => overlappedIoPromise)
+        totalWrites += writes
+        if (data.length > 0) {
+          this.log(`sent ${data.length} objects to destination ${this.outputType}, wrote ${writes}`)
+        }
+
         offset += data.length
 
         await delay(this.options.throttleInterval || 0)

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -124,11 +124,11 @@ class TransportProcessor extends EventEmitter {
         const overlappedIoPromise = this.set(data, limit, offset).catch(err => {
           // Should always emit write errors just like we do for read errors
           this.emit('error', err)
-  
+
           if (ignoreErrors) {
             return Promise.resolve(0)
           }
-  
+
           return Promise.reject(err)
         })
 

--- a/test/processor.tests.js
+++ b/test/processor.tests.js
@@ -327,9 +327,7 @@ describe('TransportProcessor', () => {
       const totalWrites = await transport._loop(1, 0, 0)
 
       // Should complete despite error
-      // FIXME: should be 1 not 0 but baseline does not emit write
-      // errors when ignore-errors is set
-      errorCount.should.equal(0)
+      errorCount.should.equal(1)
       totalWrites.should.equal(1)
       transport.outputData.should.have.length(1)
       transport.outputData[0].should.have.property('value', 'test2')

--- a/test/test.js
+++ b/test/test.js
@@ -814,7 +814,8 @@ describe('ELASTICDUMP', () => {
 
       const dumper = new Elasticdump(options.input, options.output, options)
 
-      dumper.dump(() => {
+      dumper.dump((error) => {
+        should.not.exist(error)
         const raw = fs.readFileSync('/tmp/es_out.json')
         const lineCount = String(raw).split('\n').length
         lineCount.should.equal(seedSize + 1)
@@ -842,7 +843,8 @@ describe('ELASTICDUMP', () => {
 
       const dumper = new Elasticdump(options.input, options.output, options)
 
-      dumper.dump(() => {
+      dumper.dump((error) => {
+        should.not.exist(error)
         const raw = fs.readFileSync('/tmp/out.sourceOnly')
         const lines = String(raw).split('\n')
         lines.length.should.equal(seedSize + 1)


### PR DESCRIPTION
- The writer errors are now emitted even if ignored, just like read errors are attempting to do (but does not really work for various reasons)
- Fixes hangs for `es to file` and `es to file sourceOnly` integration tests
  - These were hanging because the new code was awaiting the write of an empty output array while the old code was setting up the write in that case but then not awaiting it
  - The fix is to not even setup the write at all if we're not going to write anything