### PR TITLE
Add stop after error tests / throw and stop after read errors

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -99,12 +99,13 @@ class TransportProcessor extends EventEmitter {
       const readPromise = new Promise((resolve, reject) => {
         this.input.get(limit, offset, (err, data) => {
           if (err) {
-            this.emit('error', err)
-            if (!ignoreErrors) {
-              // This will cause `await readPromise` to throw out of the loop and
-              // out of the `__looper` function.
-              return reject(err)
-            }
+            // No need to emit the read error as _loop will emit it
+            // There can only be a single read error since we stop
+            // reading after the first read error
+
+            // This will cause `await readPromise` to throw out of the loop and
+            // out of the `__looper` function.
+            return reject(err)
           }
           resolve(data || [])
         })
@@ -122,10 +123,10 @@ class TransportProcessor extends EventEmitter {
         this.applyModifiers(data)
 
         const overlappedIoPromise = this.set(data, limit, offset).catch(err => {
-          // Should always emit write errors just like we do for read errors
-          this.emit('error', err)
-
           if (ignoreErrors) {
+            // We only emit if continuing to run after errors
+            // If stopping after errors then the catch in _loop will emit
+            this.emit('error', err)
             return Promise.resolve(0)
           }
 


### PR DESCRIPTION
- Add failing test for both read (always stops) and for write (stops only if `ignore-errors` is false)
- Read errors
   - These always have to stop
   - The docs for `ignore-errors` said: `Will continue the read/write loop on write error`
      - This implied that it can only ignore write errors, not read errors
   - The 6.117.0 code was exiting after read errors because data was a zero-length array
   - This formalizes that we're intentionally stopping on read errors and we're throwing them so they can be reported (this is regardless of `ignore-errors` property state)
- Write errors
  - These were already stopping if `ignore-errors` was `false`
  - This fixes a double-emit of the error that could cause users to think that 2 errors happened instead of 1 error