### PR TITLE
Fix this.get method

### DIFF
--- a/elasticdump.js
+++ b/elasticdump.js
@@ -54,7 +54,7 @@ class ElasticDump extends TransportProcessor {
     }
 
     // promisify helpers
-    this.get = promisify(this.output.get).bind(this.input)
+    this.get = promisify(this.input.get).bind(this.input)
     this.set = promisify(this.output.set).bind(this.output)
 
     if (!limit) { limit = this.options.limit }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -96,22 +96,7 @@ class TransportProcessor extends EventEmitter {
     const ignoreErrors = this.options['ignore-errors'] === true
 
     while (true) {
-      const readPromise = new Promise((resolve, reject) => {
-        this.input.get(limit, offset, (err, data) => {
-          if (err) {
-            // No need to emit the read error as _loop will emit it
-            // There can only be a single read error since we stop
-            // reading after the first read error
-
-            // This will cause `await readPromise` to throw out of the loop and
-            // out of the `__looper` function.
-            return reject(err)
-          }
-          resolve(data || [])
-        })
-      })
-
-      const data = await readPromise
+      const data = await this.get(limit, offset)
 
       this.log(`got ${data.length} objects from source ${this.inputType} (offset: ${offset})`)
 

--- a/test/processor.tests.js
+++ b/test/processor.tests.js
@@ -1,6 +1,9 @@
 const TransportProcessor = require('../lib/processor')
 const path = require('path')
 require('should')
+const { promisify } = require('util')
+
+const sleep = promisify(setTimeout)
 
 class MockTransport extends TransportProcessor {
   constructor (options = {}) {
@@ -10,22 +13,21 @@ class MockTransport extends TransportProcessor {
     this.outputData = []
     this.currentIndex = 0
     this.modifiers = []
+  }
 
-    // Mock input transport with get method
-    this.input = {
-      get: (limit, offset, callback) => {
-        if (this.options.simulateReadError) {
-          if (typeof this.options.simulateReadError === 'number') {
-            this.options.simulateReadError--
-          }
-          return setTimeout(() => callback(new Error('Simulated read error'), []), 0) // Simulate async error
-        }
-        const start = offset
-        const end = Math.min(start + limit, this.inputData.length)
-        const data = this.inputData.slice(start, end)
-        setTimeout(() => callback(null, data), 0) // Simulate async
+  async get (limit, offset) {
+    if (this.options.simulateReadError) {
+      if (typeof this.options.simulateReadError === 'number') {
+        this.options.simulateReadError--
       }
+      await sleep(0)
+      throw new Error('Simulated read error')
     }
+    const start = offset
+    const end = Math.min(start + limit, this.inputData.length)
+    const data = this.inputData.slice(start, end)
+    await sleep(0) // Simulate async
+    return data
   }
 
   // Mock output transport with set method


### PR DESCRIPTION
- `this.get` was a promisify version of `this.output.get` which looks like a typo
- Changed to `this.input.get`
- Processor has been patched to use `this.get` instead of the repeatedly added `new Promise` wrapper
- Unit tests have been changed to use a mock of `this.get`