### PR TITLE
Simplify stream finished

### DIFF
--- a/lib/transports/file.js
+++ b/lib/transports/file.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const { EOL } = require('os')
 const base = require('./base.js')
 const StreamSplitter = require('../splitters/streamSplitter.js')
-const { PassThrough } = require('stream')
+const { finished, PassThrough } = require('stream')
 const zlib = require('zlib')
 const util = require('util')
 
@@ -100,39 +100,18 @@ class file extends base {
       return callback(null, lineCounter)
     }
 
-    const cleanup = () => {
+    // We just need to wait for the end of the pipeline to close
+    // as the end() propagates through the pipeline
+    const streamToWait = this.fileStream || this.stream
+    finished(streamToWait, (err) => {
       delete this.stream
       delete this.fileStream
       this.closeCallback = null
-      callback(null, lineCounter)
-    }
+      callback(err, lineCounter)
+    })
 
-    if (this.fileStream) {
-      // Wait for both stream and file to close
-      let streamClosed = false
-      let fileClosed = false
-
-      const tryCleanup = () => {
-        if (streamClosed && fileClosed) {
-          cleanup()
-        }
-      }
-
-      this.stream.on('finish', () => {
-        streamClosed = true
-        tryCleanup()
-      })
-
-      this.fileStream.on('close', () => {
-        fileClosed = true
-        tryCleanup()
-      })
-
-      this.stream.end()
-    } else {
-      this.stream.on('finish', cleanup)
-      this.stream.end()
-    }
+    // Trigger close of whole pipeline
+    this.stream.end()
   }
 
   log (line) {


### PR DESCRIPTION
- We only need to wait for the final destination stream to finish
- Use `finished` from `stream` to handle all conditions under which a stream can be finished