### PR TITLE
Fix stream close from processor and add unit test

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -115,23 +115,26 @@ class TransportProcessor extends EventEmitter {
 
       this.log(`got ${data.length} objects from source ${this.inputType} (offset: ${offset})`)
 
+      // We always setup the write because data [] is used to close the stream
+      const overlappedIoPromise = this.set(data, limit, offset).catch(err => {
+        if (ignoreErrors) {
+          // We only emit if continuing to run after errors
+          // If stopping after errors then the catch in _loop will emit
+          this.emit('error', err)
+          return Promise.resolve(0)
+        }
+
+        return Promise.reject(err)
+      })
+
       if (data.length === 0) {
         await queue.onIdle()
+        // Trigger the close of the destination stream
+        await overlappedIoPromise
         // Break out of the `while (true)` loop and end the process
         return totalWrites
       } else {
         this.applyModifiers(data)
-
-        const overlappedIoPromise = this.set(data, limit, offset).catch(err => {
-          if (ignoreErrors) {
-            // We only emit if continuing to run after errors
-            // If stopping after errors then the catch in _loop will emit
-            this.emit('error', err)
-            return Promise.resolve(0)
-          }
-
-          return Promise.reject(err)
-        })
 
         // NOTE: this doesn't really do anything as `queue.add()` returns only when the passed promise resolves,
         // which is evidenced by the fact that `queue.add()` returns the resolved value of the passed promise

--- a/test/processor.tests.js
+++ b/test/processor.tests.js
@@ -384,5 +384,30 @@ describe('TransportProcessor', () => {
       duration.should.be.aboveOrEqual(100)
       transport.outputData.should.have.length(2)
     })
+
+    it('should make final zero-length write when processing completes', async () => {
+      const inputData = [
+        { id: 1, value: 'test1' },
+        { id: 2, value: 'test2' }
+      ]
+
+      const writes = []
+      const transport = new MockTransport({
+        inputData
+      })
+
+      // Track all writes including their length
+      const originalSet = transport.set.bind(transport)
+      transport.set = async (data, limit, offset) => {
+        writes.push(data.length)
+        return originalSet(data, limit, offset)
+      }
+
+      await transport._loop(1, 0, 0)
+
+      // Verify writes including final zero-length write
+      writes.should.eql([1, 1, 0])
+      transport.outputData.should.have.length(2)
+    })
   })
 })


### PR DESCRIPTION
- I did not realize that the zero length `data` write is used to initiate the stream close so I missed this on my refactor
- I don't think this matters for typical usage of the program as the streams get flushed on close - but I think it does cause problems for in-process usage in tests - it's possible it COULD cause some incomplete closes of files in typical usage though
- This adds back the zero length write
- This unit test will fail if you revert or drop the fix commit locally

## Failing Unit Test Before Fix

```
  1) TransportProcessor
       _loop
         should make final zero-length write when processing completes:

      AssertionError: expected Array [ 1, 1 ] to equal Array [ 1, 1, 0 ] (at length, A has 2 and B has 3)
      + expected - actual

       [
         1
         1
      +  0
       ]
```