### PR TITLE
Update `fast-csv`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bytes": "^3.1.2",
     "delay": "^5.0.0",
     "extends-classes": "1.0.5",
-    "fast-csv": "4.3.6",
+    "fast-csv": "5.0.2",
     "http-status": "^1.5.1",
     "ini": "^2.0.0",
     "JSONStream": "npm:@search-dump/jsonstream@^1.4.0",


### PR DESCRIPTION
## Changes
- Updates to 5.0.0 which removes `@types/node` runtime dependency that should not have been there
- Removes ~1.7 MB from runtime install
- https://github.com/C2FO/fast-csv/releases/tag/v5.0.0

## Baseline - `@types` is 1.7 MB
<img width="490" alt="image" src="https://github.com/user-attachments/assets/1151a1f9-bd4e-40a6-a56d-234d4d9825e6" />
