### PR TITLE
Remove dumb-init

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+# Git Repo
+.git
+
 # Created by .ignore support plugin (hsz.mobi)
 ### Node template
 # Logs
@@ -39,3 +42,8 @@ build/
 dist/
 test/
 .github
+
+# Docker files
+.dockerignore
+Dockerfile*
+docker-compose*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,12 @@ LABEL maintainer="ferronrsmith@gmail.com"
 ARG ES_DUMP_VER
 ARG TARGETPLATFORM
 ENV ES_DUMP_VER=${ES_DUMP_VER:-latest}
-ENV NODE_ENV production
-
-RUN apt-get -y update && \
-    apt-get -y install wget &&  \
-    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=amd64; fi && \
-    wget "https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_${ARCHITECTURE}.deb" && \
-    dpkg -i dumb-init_*.deb
+ENV NODE_ENV=production
 
 RUN npm install elasticdump@${ES_DUMP_VER} -g
 
 COPY docker-entrypoint.sh /usr/local/bin/
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
-CMD ["/usr/bin/dumb-init", "elasticdump"]
+CMD ["elasticdump"]

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -1,19 +1,19 @@
 FROM node:20-bookworm-slim
 LABEL maintainer="ferronrsmith@gmail.com"
-ENV NODE_ENV production
+ENV NODE_ENV=production
 WORKDIR /app
 
 COPY . .
 
-RUN apt-get -y update && \
-    apt-get -y install wget &&  \
-    wget https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_amd64.deb && \
-    dpkg -i dumb-init_*.deb
+RUN npm install --production --legacy-peer-deps
 
-RUN npm install --production -g
-
+# Overwrite the entrypoint script used in the base image
 COPY docker-entrypoint.sh /usr/local/bin/
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+# This is already set in the base image
+# ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
-CMD ["/usr/bin/dumb-init", "elasticdump"]
+# This will get `elasticump` and `multielasticdump` in the PATH
+RUN npm link
+
+CMD ["elasticdump"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/dumb-init /bin/sh
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
## Notes
- Dumb init does not appear to be used (if we're explicitly using it for restart behavior let me know)
- This removes 30 MB from the non-base Docker layers (of about 170 MB total)
- This makes it easier to handle Ctrl-C on `docker run` and easier to trace what's happening on `docker stop -t 30 [containerid]`
- This will go with a subsequent PR that will add graceful shutdown handling for SIGTERM and SIGINT
- Fixed the `Dockerfile_local`, prevented it from reinstalling modules when any file is changed (e.g. the dockerfile itself), and prevented from copying the entire `.git` repo into the image

## This PR - 30 MB layer is gone

<img width="1462" alt="image" src="https://github.com/user-attachments/assets/b3d6e59a-4a46-41c8-bdf5-0ee6b85c1766" />

## Baseline - 30 MB layer for `dumb-init`

<img width="1460" alt="image" src="https://github.com/user-attachments/assets/7c36a76e-ce23-47bd-9d38-55865ea2398a" />
