### PR TITLE
Add graceful shutdown on SIGINT/SIGTERM

### DIFF
--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -10,7 +10,10 @@ const { isUrl } = require(path.join(__dirname, '..', 'lib', 'is-url.js'))
 const ArgParser = require(path.join(__dirname, '..', 'lib', 'argv.js'))
 const versionCheck = require(path.join(__dirname, '..', 'lib', 'version-check.js'))
 const createSnapshot = require(path.join(__dirname, '..', 'lib', 'heap-snapshot.js'))
+const { registerGracefulShutdown } = require('../lib/shutdown')
 require('aws-sdk/lib/maintenance_mode_message').suppress = true
+
+registerGracefulShutdown()
 
 // For future developers.  If you add options here, be sure to add the option to test suite tests where necessary
 const defaults = {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -3,6 +3,7 @@ const { IterableMapper, IterableQueueMapperSimple } = require('@shutterstock/p-m
 const delay = require('delay')
 const vm = require('vm')
 const path = require('path')
+const { getIsShuttingDown } = require('./shutdown')
 
 class TransportProcessor extends EventEmitter {
   log (message) {
@@ -141,6 +142,13 @@ class TransportProcessor extends EventEmitter {
     // Iterate over the prefetched row blocks, in order
     // Typically there will always be a prefetched read so we will not wait here
     for await (const value of prefetcher) {
+      if (getIsShuttingDown()) {
+        this.log('Caught shutdown signal, waiting for writes to finish...')
+        await flusher.onIdle()
+        this.log('Writes finished, exiting...')
+        return totalWrites
+      }
+
       // Bail out if there is a write error and we are not ignoring them
       if (!ignoreErrors && flusher.errors && flusher.errors.length > 0) {
         throw flusher.errors[0]

--- a/lib/shutdown.js
+++ b/lib/shutdown.js
@@ -1,0 +1,26 @@
+let isShuttingDown = false
+
+function getIsShuttingDown () {
+  return isShuttingDown
+}
+
+function registerGracefulShutdown () {
+  process.on('SIGINT', function () {
+    if (!isShuttingDown) {
+      console.error('Caught SIGINT, exiting...')
+    }
+    isShuttingDown = true
+  })
+
+  process.on('SIGTERM', function () {
+    if (!isShuttingDown) {
+      console.error('Caught SIGTERM, exiting...')
+    }
+    isShuttingDown = true
+  })
+}
+
+module.exports = {
+  getIsShuttingDown,
+  registerGracefulShutdown
+}


### PR DESCRIPTION
## To-Do
- [ ] Change the log statements in `shutdown.js` to use `this.log` - Just not sure how to best pass this in from the `/bin/[multi]elasticdump` files where it is used
- [ ] It may be useful to change the final exit log messages to indicate that the processed exited before it completed
- [x] ~~`multielasticdump` needs to be implemented - In the child processes we can continue to handle shutdown signals as we do in `elasticdump.js` - But in the parent process we need to keep track of all of the child PIDs created and we need to send them the same signal we receive so they will exit gracefully~~
   - I think we can skip this... it exits and the use cases for `multielasticdump` are not quite what I thought they were... 
- [x] This works in conjunction with #1102 - Probably merge that first

## Notes
- SIGINT (Ctrl-C) for both Docker and local will shutdown gracefully
- SIGTERM under Docker (`docker stop`) or kubernetes (or similar - `kubectl delete po`) will gracefully stop writing to the output
- Before this PR, both signals are ignored and the process keeps running

## This PR

<details>
<summary>
Use replacement `Dockerfile_local` to address build issues covered in #1102 
</summary>

```Dockerfile
FROM node:20-bookworm-slim
LABEL maintainer="ferronrsmith@gmail.com"
ARG TARGETPLATFORM
ENV NODE_ENV production
WORKDIR /app

COPY . .

RUN apt-get -y update && \
    apt-get -y install wget &&  \
    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=amd64; fi && \
    wget "https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_${ARCHITECTURE}.deb" && \
    dpkg -i dumb-init_*.deb

RUN npm install --production --legacy-peer-deps

RUN npm link

COPY docker-entrypoint.sh /usr/local/bin/

ENTRYPOINT ["docker-entrypoint.sh"]

CMD ["/usr/bin/dumb-init", "elasticdump"]
```
</details>

Build image with:

```sh
docker build -f Dockerfile_local --build-arg TARGET_PLATFORM=linux/arm64  . --tag elasticdump/elasticsearch-dump-local
```

### SIGINT - Docker Run - Ctrl C

Note: `-local` suffix on image

```
docker run elasticdump/elasticsearch-dump-local --input=https://some-host/some-index --output=https:/some-host/some-index --type=data --input-params="{\"preference\":\"_shards:0\"}" --concurrency=10 --esCompress=true
```

<img width="1259" alt="image" src="https://github.com/user-attachments/assets/409ee918-9a01-424f-9553-3a8b4408b596" />

1. Run as above
2. Press Ctrl-C
3. Observe `^C` in output
4. Observe log messages in output indicating graceful exit is starting
5. Observe that the container exits within a few seconds

### SIGTERM - Docker Run - `docker stop -t 30 [containerid]`

Note: `-local` suffix on image

```
docker run elasticdump/elasticsearch-dump-local --input=https://some-host/some-index --output=https:/some-host/some-index --type=data --input-params="{\"preference\":\"_shards:0\"}" --concurrency=10 --esCompress=true
```

<img width="1306" alt="image" src="https://github.com/user-attachments/assets/84c61dec-62a0-41d9-9e88-08eec117c134" />

1. Run as above
2. `docker ps` to get container id`
3. `docker stop -t 30 [containerid]`
4. Observe that `elasticdump` container logs messages indicating it is exiting and exits within a couple of seconds
7. Observe that `docker stop` returns within a few seconds, not at the end of the 30 second grace period (because PID 1 has exited so the container is done)

## Baseline

### SIGINT - Docker Run - Ctrl C

```sh
docker run elasticdump/elasticsearch-dump --input=https://some-host/some-index --output=https:/some-host/some-index --type=data --input-params="{\"preference\":\"_shards:0\"}" --concurrency=10 --esCompress=true
```

1. Run as above
2. Press Ctrl-C
3. Observe `^C` in output
4. Keeps running indefinitely

<img width="1264" alt="image" src="https://github.com/user-attachments/assets/f10db9dc-46b4-41d3-b14e-6b52163b0ac6" />

### SIGTERM - Docker Run - `docker stop -t 30 [containerid]`

```sh
docker run elasticdump/elasticsearch-dump --input=https://some-host/some-index --output=https:/some-host/some-index --type=data --input-params="{\"preference\":\"_shards:0\"}" --concurrency=10 --esCompress=true
```

1. Run as above
2. `docker ps` to get container id`
3. `docker stop -t 30 [containerid]`
4. Observe that `elasticdump` container continues running for 30 seconds and `docker stop` does not return for 30 seconds
7. At the end of the 30 second grace period, the container is killed, without correctly closing any outputs
