### PR TITLE
Fix elastic/opensearch version parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,8 @@ Options
                     NB : Type validation is handled by the bulk endpoint and not by elasticsearch-dump
 
 --openSearchServerless
-                    Set to true to run dump from AWS OpenSearch serverless collection.
+                    Set to true to force elasticsearch-dump think the connected cluster is on AWS OpenSearch Serverless
+                    elasticsearch-dump will detect cluster flavor automatically. This flag isn't needed usually.
                     (default : false)
 
 --searchAfter

--- a/lib/aws4signer.js
+++ b/lib/aws4signer.js
@@ -73,7 +73,7 @@ const aws4signer = async (esRequest, parent) => {
     esRequest.headers = Object.assign({ host: urlObj.hostname, 'Content-Type': 'application/json' }, esRequest.headers)
     esRequest.path = `${urlObj.pathname}?${urlObj.searchParams.toString()}`
 
-    if (parent.options.openSearchServerless) {
+    if (parent.ESDistribution === "opensearch-serverless") {
       esRequest.headers = Object.assign({ 'X-Amz-Content-SHA256': calculateSHA256(esRequest.body) }, esRequest.headers)
     }
     return aws4.sign(esRequest, credentials)

--- a/lib/transports/__es__/_base.js
+++ b/lib/transports/__es__/_base.js
@@ -36,19 +36,56 @@ class Base {
     }
   }
 
-  version (prefix, callback) {
-    if (this.ESversion) {
-      return callback()
+  /**
+   * @returns {{version: string, distribution: string, distributionVersion: string}}
+   */
+  _parseVersion (response) {
+    // Skip `this.handleError` if server is AOSS
+    // They didn't implement `GET /` and will return 404 here, but we can hard-code
+    // the version info by `server` in response header
+    if (this.parent.options.openSearchServerless || response.headers.server === "aoss-amazon") {
+      return {
+        version: this.parent.options['force-os-version'],
+        distribution: 'opensearch-serverless',
+        // See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-overview.html
+        // "Currently, serverless collections run OpenSearch version 2.0.x", as of May 13, 2025
+        distributionVersion: '2.0.0'
+      }
     }
 
-    if (this.parent.options.openSearchServerless) {
-      // OpenSearch serverless default version
-      // See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-overview.html
-      // "Currently, serverless collections run OpenSearch version 2.0.x", as of May 13, 2025
-      this.ESversion = 2
-      this.ESFullversion = '2.0.0'
-      this.parent.emit('debug', `opensearch serverless, using version: ${this.ESversion}`)
-      this.setSearchBody()
+    const err = this.handleError(null, response)
+    if (err) {
+      throw err
+    }
+
+    const parsed = jsonParser.parse(response.body)
+    if (!parsed.version) {
+      // Fallback version
+      this.parent.emit('debug', `unable to detect version, using default: 5.0.0`)
+      return {
+        version: '5.0.0',
+        distribution: 'elasticsearch',
+        distributionVersion: '5.0.0',
+      }
+    }
+
+    if (parsed.version.distribution === 'opensearch') {
+      return {
+        version: this.parent.options['force-os-version'],
+        distribution: 'opensearch',
+        distributionVersion: parsed.version.number,
+      }
+    }
+
+    return {
+      version: parsed.version.number,
+      distribution: parsed.version.build_flavor === "serverless" ? 'elasticsearch-serverless' : 'elasticserach',
+      distributionVersion: parsed.version.number,
+    }
+  }
+
+  version (prefix, callback) {
+    if (this.ESversion) {
       return callback()
     }
 
@@ -59,33 +96,25 @@ class Base {
 
     aws4signer(esRequest, this.parent).then(() => {
       this.baseRequest(esRequest, (err, response) => {
-        err = this.handleError(err, response)
         if (err) {
           return callback(err, [])
         }
 
-        const parsed = jsonParser.parse(response.body)
+        const parsed = this._parseVersion(response)
 
-        // Set version based on response
-        if (parsed.version) {
-          const isOpenSearch = parsed.version.distribution === 'opensearch'
-          this.ESFullversion = isOpenSearch
-            ? this.parent.options['force-os-version']
-            : parsed.version.number
-          this.ESversion = this.ESFullversion.split('.')[0]
+        this.parent.emit('debug', `detected ${prefix} distribution = ${parsed.distribution}, ESversion = ${parsed.version}, distribution version = ${parsed.distributionVersion}`)
 
-          // Version check for searchAfter
-          if (this.parent.options.searchAfter && !isOpenSearch) {
-            if (!semver.gte(this.ESFullversion, '7.17.0')) {
-              return callback(new Error('searchAfter requires Elasticsearch 7.17.0 or higher'))
-            }
+        // No need to check elasticsearch-serverless. Those are at least >= v8
+        if (this.parent.options.searchAfter && parsed.distribution === "elasticsearch") {
+          if (!semver.gte(this.ESFullversion, '7.17.0')) {
+            return callback(new Error('searchAfter requires Elasticsearch 7.17.0 or higher'))
           }
-
-          this.parent.emit('debug', `detected ${prefix} ${isOpenSearch ? 'opensearch' : 'elasticsearch'} version: ${this.ESversion}`)
-        } else {
-          this.ESversion = 5 // Fallback version
-          this.parent.emit('debug', `unable to detect version, using default: ${this.ESversion} for ${prefix}`)
         }
+
+        this.ESFullversion = parsed.version
+        this.ESversion = this.ESFullversion.split('.')[0]
+        this.ESDistribution = parsed.distribution
+        this.DistributionVersion = parsed.distributionVersion
 
         this.setSearchBody()
         callback()

--- a/lib/transports/__es__/_base.js
+++ b/lib/transports/__es__/_base.js
@@ -42,7 +42,11 @@ class Base {
     }
 
     if (this.parent.options.openSearchServerless) {
-      this.ESversion = 2 // OpenSearch serverless default version
+      // OpenSearch serverless default version
+      // See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-overview.html
+      // "Currently, serverless collections run OpenSearch version 2.0.x", as of May 13, 2025
+      this.ESversion = 2
+      this.ESFullversion = '2.0.0'
       this.parent.emit('debug', `opensearch serverless, using version: ${this.ESversion}`)
       this.setSearchBody()
       return callback()

--- a/lib/transports/__es__/_data.js
+++ b/lib/transports/__es__/_data.js
@@ -134,7 +134,7 @@ class Data {
     const payload = {
       url: thisUrl,
       body: '',
-      method: this.parent.options.openSearchServerless ? 'POST' : 'PUT',
+      method: this.ESDistribution === "opensearch-serverless" ? 'POST' : 'PUT',
       headers: Object.assign({
         'User-Agent': 'elasticdump',
         'Content-Type': 'application/x-ndjson'
@@ -145,7 +145,7 @@ class Data {
     const bulkAction = this.parent.options.bulkAction || 'index'
 
     data.forEach(elem => {
-      if (this.parent.options.openSearchServerless) {
+      if (this.ESDistribution === "opensearch-serverless") {
         delete elem._id
         delete elem.fields
       }

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -43,8 +43,42 @@ class elasticsearch extends Many(Base, Alias, Analyzer, Mapping, Policy, Setting
     this.totalSearchResults = 0
     this.elementsToSkip = 0
     this.searchBody = this.parent.options.searchBody
+    /**
+     * Major elastic version.
+     *
+     * For alternative distributions (OpenSearch), this will be the version they claims
+     * to be compatible with.
+     *
+     * @type {string}
+     */
     this.ESversion = null
+    /**
+     * Full elastic version.
+     *
+     * For alternative distributions (OpenSearch), this will be the version they claims
+     * to be compatible with.
+     *
+     * @type {string}
+     */
     this.ESFullversion = null
+    /**
+     * Elastic distribution, or flavor.
+     *
+     * Use `.startsWith(...)` if the check does not care the target is serverless or not.
+     *
+     * @type {'elastic' | 'elastic-serverless' | 'opensearch' | 'opensearch-serverless'}
+     */
+    this.ESDistribution = null
+    /**
+     * Distribution version.
+     *
+     * For elastic and elastic-serverless distributions, this is identical to ESVersion.
+     *
+     * For other distributions, this is the actual version the server is running.
+     *
+     * @type {string}
+     */
+    this.DistributionVersion = null
     this.featureFlag = false
 
     const defaultOptions = {
@@ -99,7 +133,7 @@ class elasticsearch extends Many(Base, Alias, Analyzer, Mapping, Policy, Setting
       if (err) { return callback(err) }
 
       if (type === 'data') {
-        if (this.parent.options.openSearchServerless) {
+        if (this.ESDistribution === "opensearch-serverless") {
           this.getOpenSearchServerlessData(limit, offset, callback)
         } else {
           this.getData(limit, offset, callback)


### PR DESCRIPTION
Got weird error when trying to dump index template:

```
./bin/elasticdump --input=https://xxxxxx.us-west-2.aoss.amazonaws.com --output=$HOME/dump/dump4.ndjson --openSearchServerless=true --awsChain=true --pit=true --searchAfter=true --type=index_template --overwrite
Debugger attached.
Tue, 13 May 2025 18:18:47 GMT | starting dump
Tue, 13 May 2025 18:19:03 GMT | Error Emitted => Invalid version. Must be a string. Got type "object".
Tue, 13 May 2025 18:19:03 GMT | Total Writes: 0
Tue, 13 May 2025 18:19:03 GMT | dump ended with error (get phase) => TypeError: Invalid version. Must be a string. Got type "object".
Waiting for the debugger to disconnect...
```

After adding the missing `ESFullversion` property, we get:

```
dump ended with error (get phase) => Error: feature not supported in Elasticsearch 2.0.0, only version 7.8.0 or higher
```

Should we use `this.parent.options['force-os-version']` here instead? 2.0.0 is basically blocking all version check.